### PR TITLE
Fix MagnitudePercentageRatio bench test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-—
+- Benchmark and test for `MagnitudePercentageRatio`
 
 ### Security
 

--- a/light-curve/tests/test_w_bench.py
+++ b/light-curve/tests/test_w_bench.py
@@ -275,17 +275,19 @@ def generate_test_magnitude_percentile_ratio(quantile_numerator, quantile_denume
         f"TestMagnitudePercentageRatio{int(quantile_numerator * 100):d}",
         (_Test,),
         dict(
+            args=(quantile_numerator, quantile_denumerator),
             quantile_numerator=quantile_numerator,
             quantile_denumerator=quantile_denumerator,
             name="MagnitudePercentageRatio",
+            feets_feature=feets_feature,
             feets_skip_test="feets uses different quantile type",
         ),
     )
 
 
-generate_test_magnitude_percentile_ratio(0.40, 0.05, "FluxPercentileRatioMid20")
-generate_test_magnitude_percentile_ratio(0.25, 0.05, "FluxPercentileRatioMid50")
-generate_test_magnitude_percentile_ratio(0.10, 0.05, "FluxPercentileRatioMid80")
+FluxPercentileRatioMid20 = generate_test_magnitude_percentile_ratio(0.40, 0.05, "FluxPercentileRatioMid20")
+FluxPercentileRatioMid50 = generate_test_magnitude_percentile_ratio(0.25, 0.05, "FluxPercentileRatioMid50")
+FluxPercentileRatioMid80 = generate_test_magnitude_percentile_ratio(0.10, 0.05, "FluxPercentileRatioMid80")
 
 
 class TestMaximumSlope(_Test):


### PR DESCRIPTION
There was a bug in the implementation of test class generator function for benchmarking and cross-testing `MagnitudePercentageRatio`. This error didn't show itself for a long time because the return value (test-class) of this function wasn't assigned to any value and probably was dropped by the garbage collector, which is another bug fixe3d by this issue. (I'm not sure about this GC hypnosis, but if it is true, then I haven't believed into "everything is an object" idea enough when wrote that code.) However our GH actions CI shown this error a couple of time for python 3.8 (I have no idea why this version only) on both Linux and macOS.

A "prove" of the GC hypnosis
```python
>>> class A:
...     pass
...
>>> # "and 1" is for ipython to hide an output and prevent implicit saving
>>> (lambda: type('B', (A,), {}))() and 1
1
>>> import gc
>>> gc.collect()
3
>>> print(A.__subclasses__())
[]
```