### PR TITLE
Ignore clippy::boroow_deref_ref on a module level

### DIFF
--- a/light-curve/src/dmdt.rs
+++ b/light-curve/src/dmdt.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::borrow_deref_ref)] // https://github.com/rust-lang/rust-clippy/issues/8971
+
 use crate::check::check_sorted;
 use crate::cont_array::{ContArray, ContCowArray};
 use crate::errors::{Exception, Res};


### PR DESCRIPTION
It is caused by same bug in clippy
https://github.com/rust-lang/rust-clippy/issues/8971