### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        interpreter: [cp37-manylinux, cp38-manylinux, cp39-manylinux, cp310-manylinux]
+        interpreter: [cp37-manylinux, cp38-manylinux, cp39-manylinux, cp310-manylinux, cp311-manylinux]
         arch: [aarch64, ppc64le]
         include:
           - os: macos-11   # All x86_64 macOS targets

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           package-dir: ./light-curve
         env:
-          CIBW_SKIP: "*-musllinux_i686 cp311-*"  # rustup doesn't install i686-musl | we don't support 3.11 yet
+          CIBW_SKIP: "*-musllinux_i686"  # rustup doesn't install i686-musl
           CIBW_BUILD_VERBOSITY: "3"
 
       - name: Upload wheels as artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_minor: ['7', '8', '9', '10']
+        python_minor: ['7', '8', '9', '10', '11']
 
     defaults:
       run:
@@ -113,6 +113,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
     - name: Install maturin
       run: pip install 'maturin>=0.13,<0.14'
     - name: Build for ${{ matrix.name }}
@@ -143,6 +147,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
     - name: Get minimum supported Rust version
       run: echo "::set-output name=msrv::$(grep '^rust-version = ' Cargo.toml | grep -o '[0-9.]\+')"
       id: get_msrv

--- a/light-curve/pyproject.toml
+++ b/light-curve/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
@@ -53,29 +54,30 @@ testpaths = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 isolated_build = True
 
 [testenv]
 deps =
+    black
+    feets
+    isort
+    numpy
     pytest
     pytest-benchmark
     pytest-markdown
-    numpy
     scipy
-    feets
-commands = pytest README.md tests/ light_curve/
+commands =
+    pytest README.md tests/ light_curve/
+    black --check .
+    isort --check .
 """
 
-
-[tool.cibuildwheel]
-# We do not support 3.11 yet
-skip = "cp311-*"
 
 # Test
 # We skip benchmark tests, because it requires feets and its transitive
 # dependencies, which are tricky and slow to compile on marginal platforms.
-# We use platforms where scipy binary wheels are available
+# For testing we use only platforms for which scipy binary wheels are available
 [[tool.cibuildwheel.overrides]]
 select = "cp*-manylinux_x86_64 cp*-manylinux_aarch64 cp*-macosx*"
 test-command = "pytest {package}/README.md {package}/light_curve/ {package}/tests/ --ignore {package}/tests/test_w_bench.py"


### PR DESCRIPTION
Fix #108 

- [x] `pyo3` looks like it supports 3.11 for a while
- [x] `rust-numpy`
- [x] `numpy` 1.23.2
- [x] pyproject.toml fixes
- [ ] `black` doesn't support "py311" target yet (v22.10.0)
- [ ] test CI fixes
- [ ] CI tests blocked by `statsmodel` (transitive dependency of `feets`) https://github.com/statsmodels/statsmodels/issues/8287 https://github.com/statsmodels/statsmodels/pull/8467
- [x] CI building on windows is blocked by GitHub Actions toolchain https://github.com/PyO3/maturin/issues/1221
- [x] publish CI fixes
- [x] README update