### PR TITLE
Rename fftw-* cargo features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,19 +57,19 @@ jobs:
           os: 'macos-11'
           maturin_build_args: '--locked'
           install_fftw: false
-        - name: 'Linux, dynamically linked FFTW'
+        - name: 'Linux, system FFTW'
           os: 'ubuntu-latest'
           maturin_build_args: '--locked --no-default-features --features fftw-dynamic'
           install_fftw: true
-        - name: 'macOS, dynamically linked FFTW'
+        - name: 'macOS, system FFTW'
           os: 'macos-11'
           maturin_build_args: '--locked --no-default-features --features fftw-dynamic'
           install_fftw: true
-        - name: 'Linux, dynamically linked FFTW + GSL'
+        - name: 'Linux, system FFTW + GSL'
           os: 'ubuntu-latest'
           maturin_build_args: '--locked --no-default-features --features fftw-dynamic,gsl'
           install_fftw: true
-        - name: 'macOS, dynamically linked FFTW + GSL'
+        - name: 'macOS, system FFTW + GSL'
           os: 'macos-11'
           maturin_build_args: '--locked --no-default-features --features fftw-dynamic,gsl'
           install_fftw: true
@@ -77,7 +77,7 @@ jobs:
           os: 'ubuntu-latest'
           maturin_build_args: '--locked --no-default-features --features mkl,gsl'
           install_fftw: false
-        - name: 'Windows, statically linked FFTW'
+        - name: 'Windows, statically linked FFTW for fftw-src'
           os: 'windows-latest'
           maturin_build_args: '--locked --no-default-features --features fftw-static'
           install_fftw: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- cargo features "fftw-dynamic" and "fftw-static" are renamed to "fftw-system" and "fftw-source" correspondingly
+- cargo features "fftw-dynamic", "fftw-static" and "mkl" are renamed to "fftw-system", "fftw-source" and "fftw-mkl" correspondingly
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-—
+- cargo features "fftw-dynamic" and "fftw-static" are renamed to "fftw-system" and "fftw-source" correspondingly
 
 ### Removed
 

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -23,7 +23,8 @@ fftw-source = ["light-curve-feature/fftw-source"]
 fftw-static = ["fftw-source"] # deprecated
 fftw-system = ["light-curve-feature/fftw-system"]
 fftw-dynamic = ["fftw-system"] # deprecated
-mkl = ["light-curve-feature/fftw-mkl"]
+fftw-mkl = ["light-curve-feature/fftw-mkl"]
+mkl = ["fftw-mkl"] # deprecated
 gsl = ["light-curve-feature/gsl"]
 
 [dependencies]

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -18,9 +18,11 @@ lto = true
 codegen-units = 1
 
 [features]
-default = ["fftw-static", "gsl"]
-fftw-static = ["light-curve-feature/fftw-source"]
-fftw-dynamic = ["light-curve-feature/fftw-system"]
+default = ["fftw-source", "gsl"]
+fftw-source = ["light-curve-feature/fftw-source"]
+fftw-static = ["fftw-source"] # deprecated
+fftw-system = ["light-curve-feature/fftw-system"]
+fftw-dynamic = ["fftw-system"] # deprecated
 mkl = ["light-curve-feature/fftw-mkl"]
 gsl = ["light-curve-feature/gsl"]
 

--- a/light-curve/src/lib.rs
+++ b/light-curve/src/lib.rs
@@ -24,6 +24,14 @@ mod check;
 ///
 /// dm-lg(dt) maps generator is represented by `DmDt` class, while all other classes are
 /// feature extractors
+#[cfg_attr(
+    feature = "fftw-static",
+    deprecated(note = "fftw-static feature is deprecated")
+)]
+#[cfg_attr(
+    feature = "fftw-dynamic",
+    deprecated(note = "fftw-dynamic feature is deprecated")
+)]
 #[pymodule]
 fn light_curve(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
@@ -39,17 +47,17 @@ fn light_curve(py: Python, m: &PyModule) -> PyResult<()> {
         }
     })?;
     m.add("_fft_backend", {
-        #[cfg(feature = "fftw-static")]
+        #[cfg(feature = "fftw-source")]
         {
-            "statically linked FFTW"
+            "FFTW built from source by fftw-src crate and statically linked into the module"
         }
-        #[cfg(feature = "fftw-dynamic")]
+        #[cfg(feature = "fftw-system")]
         {
-            "dynamically linked FFTW"
+            "FFTW linked from system, may or may not be bundled into the package"
         }
         #[cfg(feature = "mkl")]
         {
-            "Intel MKL"
+            "Intel MKL linked statically"
         }
     })?;
 


### PR DESCRIPTION
Currently features `fftw-dynamic` and `fftw-static` have misleading names. Actually `fftw-static` always links statically with a library built by `fftw-src` crate, while `fftw-dynamic` links agains system FFTW, which could be static one.

We deprecate old names and provide new `fftw-system` and `fftw-source` instead. We also renamed `mkl` to `fftw-mkl` (which is for static linking against MKL downloaded automatically) to make it more homogeneous