### PR TITLE
out=None argument for __call__ and many

### DIFF
--- a/light-curve/src/dmdt.rs
+++ b/light-curve/src/dmdt.rs
@@ -55,12 +55,12 @@ where
     n_jobs: usize,
 }
 
-impl<'a, T> GenericDmDt<T>
+impl<'py, T> GenericDmDt<T>
 where
     T: Element + ndarray::NdFloat + lcdmdt::ErfFloat,
-    Arr<'a, T>: TryFrom<GenericFloatArray1<'a>>,
+    Arr<'py, T>: TryFrom<GenericFloatArray1<'py>>,
 {
-    fn sigma_to_err2(sigma: Arr<'a, T>) -> ContArray<T> {
+    fn sigma_to_err2(sigma: Arr<'py, T>) -> ContArray<T> {
         let mut a: ContArray<_> = sigma.as_array().into();
         a.0.mapv_inplace(|x| x.powi(2));
         a
@@ -86,7 +86,7 @@ where
         }
     }
 
-    fn py_count_dt(&self, py: Python, t: Arr<'a, T>, sorted: Option<bool>) -> Res<PyObject> {
+    fn py_count_dt(&self, py: Python, t: Arr<'py, T>, sorted: Option<bool>) -> Res<PyObject> {
         self.count_dt(
             ContCowArray::from_view(t.as_array(), true).as_slice(),
             sorted,
@@ -102,7 +102,7 @@ where
     fn py_count_dt_many(
         &self,
         py: Python,
-        t_: Vec<GenericFloatArray1<'a>>,
+        t_: Vec<GenericFloatArray1<'py>>,
         sorted: Option<bool>,
     ) -> Res<PyObject> {
         let wrapped_t_ = t_
@@ -154,8 +154,8 @@ where
     fn py_points(
         &self,
         py: Python,
-        t: Arr<'a, T>,
-        m: Arr<'a, T>,
+        t: Arr<'py, T>,
+        m: Arr<'py, T>,
         sorted: Option<bool>,
     ) -> Res<PyObject> {
         Ok(self
@@ -179,15 +179,15 @@ where
     fn py_points_many(
         &self,
         py: Python,
-        lcs: Vec<(GenericFloatArray1<'a>, GenericFloatArray1<'a>)>,
+        lcs: Vec<(GenericFloatArray1<'py>, GenericFloatArray1<'py>)>,
         sorted: Option<bool>,
     ) -> Res<PyObject> {
         let wrapped_lcs = lcs
             .into_iter()
             .enumerate()
             .map(|(i, (t, m))| {
-                let t: Result<Arr<'a, T>, _> = t.try_into();
-                let m: Result<Arr<'a, T>, _> = m.try_into();
+                let t: Result<Arr<'py, T>, _> = t.try_into();
+                let m: Result<Arr<'py, T>, _> = m.try_into();
                 match (t, m) {
                     (Ok(t), Ok(m)) => Ok((t, m)),
                     _ => Err(Exception::TypeError(format!(
@@ -240,7 +240,7 @@ where
     #[allow(clippy::too_many_arguments)]
     fn generic_dmdt_points_batches(
         &self,
-        lcs: Vec<(GenericFloatArray1<'a>, GenericFloatArray1<'a>)>,
+        lcs: Vec<(GenericFloatArray1<'py>, GenericFloatArray1<'py>)>,
         sorted: Option<bool>,
         batch_size: usize,
         yield_index: bool,
@@ -252,8 +252,8 @@ where
             .into_iter()
             .enumerate()
             .map(|(i, (t, m))| {
-                let t: Result<Arr<'a, T>, _> = t.try_into();
-                let m: Result<Arr<'a, T>, _> = m.try_into();
+                let t: Result<Arr<'py, T>, _> = t.try_into();
+                let m: Result<Arr<'py, T>, _> = m.try_into();
                 match (t, m) {
                     (Ok(t), Ok(m)) => {
                         let t: ContArray<_> = t.as_array().into();
@@ -283,9 +283,9 @@ where
     fn py_gausses(
         &self,
         py: Python,
-        t: Arr<'a, T>,
-        m: Arr<'a, T>,
-        sigma: Arr<'a, T>,
+        t: Arr<'py, T>,
+        m: Arr<'py, T>,
+        sigma: Arr<'py, T>,
         sorted: Option<bool>,
     ) -> Res<PyObject> {
         let err2 = Self::sigma_to_err2(sigma);
@@ -321,9 +321,9 @@ where
         &self,
         py: Python,
         lcs: Vec<(
-            GenericFloatArray1<'a>,
-            GenericFloatArray1<'a>,
-            GenericFloatArray1<'a>,
+            GenericFloatArray1<'py>,
+            GenericFloatArray1<'py>,
+            GenericFloatArray1<'py>,
         )>,
         sorted: Option<bool>,
     ) -> Res<PyObject> {
@@ -393,9 +393,9 @@ where
     fn generic_dmdt_gausses_batches(
         &self,
         lcs: Vec<(
-            GenericFloatArray1<'a>,
-            GenericFloatArray1<'a>,
-            GenericFloatArray1<'a>,
+            GenericFloatArray1<'py>,
+            GenericFloatArray1<'py>,
+            GenericFloatArray1<'py>,
         )>,
         sorted: Option<bool>,
         batch_size: usize,
@@ -408,9 +408,9 @@ where
             .into_iter()
             .enumerate()
             .map(|(i, (t, m, sigma))| {
-                let t: Result<Arr<'a, T>, _> = t.try_into();
-                let m: Result<Arr<'a, T>, _> = m.try_into();
-                let sigma: Result<Arr<'a, T>, _> = sigma.try_into();
+                let t: Result<Arr<'py, T>, _> = t.try_into();
+                let m: Result<Arr<'py, T>, _> = m.try_into();
+                let sigma: Result<Arr<'py, T>, _> = sigma.try_into();
                 match (t, m, sigma) {
                     (Ok(t), Ok(m), Ok(sigma)) => {
                         let t: ContArray<_> = t.as_array().into();
@@ -964,9 +964,9 @@ impl DmDt {
         n_jobs = -1,
         approx_erf = "false"
     )]
-    fn __new__<'a>(
-        dt: Arr<'a, f64>,
-        dm: Arr<'a, f64>,
+    fn __new__<'py>(
+        dt: Arr<'py, f64>,
+        dm: Arr<'py, f64>,
         dm_type: &str,
         dt_type: &str,
         norm: Vec<&str>,
@@ -983,7 +983,7 @@ impl DmDt {
             "asis" => GridType::Generic,
             _ => {
                 return Err(Exception::ValueError(
-                    "dt_type must be 'auto', 'linear', 'log' or 'asis'".to_owned(),
+                    "dt_type must be 'pyuto', 'linear', 'log' or 'pysis'".to_owned(),
                 ))
             }
         };
@@ -994,7 +994,7 @@ impl DmDt {
             "asis" => GridType::Generic,
             _ => {
                 return Err(Exception::ValueError(
-                    "dm_type must be 'auto', 'linear', 'log' or 'asis'".to_owned(),
+                    "dm_type must be 'pyuto', 'linear', 'log' or 'pysis'".to_owned(),
                 ))
             }
         };

--- a/light-curve/src/features.rs
+++ b/light-curve/src/features.rs
@@ -319,6 +319,7 @@ impl PyFeatureEvaluator {
         Ok(out.to_object(py))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn many_impl<T>(
         feature_evaluator: &lcf::Feature<T>,
         lcs: Vec<PyLightCurve<T>>,
@@ -497,6 +498,7 @@ impl PyFeatureEvaluator {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[doc = METHOD_MANY_DOC!()]
     #[args(lcs, sorted = "None", check = "true", fill_value = "None", n_jobs = -1)]
     fn many(

--- a/light-curve/src/np_array.rs
+++ b/light-curve/src/np_array.rs
@@ -1,21 +1,22 @@
-use numpy::PyReadonlyArray1;
+use numpy::{PyReadonlyArray1, PyReadwriteArray1};
 use pyo3::prelude::*;
 use std::convert::TryFrom;
 
-pub(crate) type Arr<'a, T> = PyReadonlyArray1<'a, T>;
+pub(crate) type Arr<'py, T> = PyReadonlyArray1<'py, T>;
+pub(crate) type RwArr<'py, T> = PyReadwriteArray1<'py, T>;
 
 #[derive(FromPyObject)]
-pub(crate) enum GenericFloatArray1<'a> {
+pub(crate) enum GenericFloatArray1<'py> {
     #[pyo3(transparent, annotation = "np.ndarray[float32]")]
-    Float32(Arr<'a, f32>),
+    Float32(Arr<'py, f32>),
     #[pyo3(transparent, annotation = "np.ndarray[float64]")]
-    Float64(Arr<'a, f64>),
+    Float64(Arr<'py, f64>),
 }
 
-impl<'a> TryFrom<GenericFloatArray1<'a>> for Arr<'a, f32> {
+impl<'py> TryFrom<GenericFloatArray1<'py>> for Arr<'py, f32> {
     type Error = ();
 
-    fn try_from(value: GenericFloatArray1<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: GenericFloatArray1<'py>) -> Result<Self, Self::Error> {
         match value {
             GenericFloatArray1::Float32(a) => Ok(a),
             GenericFloatArray1::Float64(_) => Err(()),
@@ -23,13 +24,43 @@ impl<'a> TryFrom<GenericFloatArray1<'a>> for Arr<'a, f32> {
     }
 }
 
-impl<'a> TryFrom<GenericFloatArray1<'a>> for Arr<'a, f64> {
+impl<'py> TryFrom<GenericFloatArray1<'py>> for Arr<'py, f64> {
     type Error = ();
 
-    fn try_from(value: GenericFloatArray1<'a>) -> Result<Self, Self::Error> {
+    fn try_from(value: GenericFloatArray1<'py>) -> Result<Self, Self::Error> {
         match value {
             GenericFloatArray1::Float32(_) => Err(()),
             GenericFloatArray1::Float64(a) => Ok(a),
+        }
+    }
+}
+
+#[derive(FromPyObject)]
+pub(crate) enum GenericFloatRwArray1<'py> {
+    #[pyo3(transparent, annotation = "np.ndarray[float32]")]
+    Float32(RwArr<'py, f32>),
+    #[pyo3(transparent, annotation = "np.ndarray[float64]")]
+    Float64(RwArr<'py, f64>),
+}
+
+impl<'py> TryFrom<GenericFloatRwArray1<'py>> for RwArr<'py, f32> {
+    type Error = ();
+
+    fn try_from(value: GenericFloatRwArray1<'py>) -> Result<Self, Self::Error> {
+        match value {
+            GenericFloatRwArray1::Float32(a) => Ok(a),
+            GenericFloatRwArray1::Float64(_) => Err(()),
+        }
+    }
+}
+
+impl<'py> TryFrom<GenericFloatRwArray1<'py>> for RwArr<'py, f64> {
+    type Error = ();
+
+    fn try_from(value: GenericFloatRwArray1<'py>) -> Result<Self, Self::Error> {
+        match value {
+            GenericFloatRwArray1::Float32(_) => Err(()),
+            GenericFloatRwArray1::Float64(a) => Ok(a),
         }
     }
 }

--- a/light-curve/src/np_array.rs
+++ b/light-curve/src/np_array.rs
@@ -1,9 +1,8 @@
-use numpy::{PyReadonlyArray1, PyReadwriteArray1};
+use numpy::{PyReadonlyArray1, PyReadwriteArray1, PyReadwriteArray2};
 use pyo3::prelude::*;
 use std::convert::TryFrom;
 
 pub(crate) type Arr<'py, T> = PyReadonlyArray1<'py, T>;
-pub(crate) type RwArr<'py, T> = PyReadwriteArray1<'py, T>;
 
 #[derive(FromPyObject)]
 pub(crate) enum GenericFloatArray1<'py> {
@@ -38,12 +37,12 @@ impl<'py> TryFrom<GenericFloatArray1<'py>> for Arr<'py, f64> {
 #[derive(FromPyObject)]
 pub(crate) enum GenericFloatRwArray1<'py> {
     #[pyo3(transparent, annotation = "np.ndarray[float32]")]
-    Float32(RwArr<'py, f32>),
+    Float32(PyReadwriteArray1<'py, f32>),
     #[pyo3(transparent, annotation = "np.ndarray[float64]")]
-    Float64(RwArr<'py, f64>),
+    Float64(PyReadwriteArray1<'py, f64>),
 }
 
-impl<'py> TryFrom<GenericFloatRwArray1<'py>> for RwArr<'py, f32> {
+impl<'py> TryFrom<GenericFloatRwArray1<'py>> for PyReadwriteArray1<'py, f32> {
     type Error = ();
 
     fn try_from(value: GenericFloatRwArray1<'py>) -> Result<Self, Self::Error> {
@@ -54,13 +53,43 @@ impl<'py> TryFrom<GenericFloatRwArray1<'py>> for RwArr<'py, f32> {
     }
 }
 
-impl<'py> TryFrom<GenericFloatRwArray1<'py>> for RwArr<'py, f64> {
+impl<'py> TryFrom<GenericFloatRwArray1<'py>> for PyReadwriteArray1<'py, f64> {
     type Error = ();
 
     fn try_from(value: GenericFloatRwArray1<'py>) -> Result<Self, Self::Error> {
         match value {
             GenericFloatRwArray1::Float32(_) => Err(()),
             GenericFloatRwArray1::Float64(a) => Ok(a),
+        }
+    }
+}
+
+#[derive(FromPyObject)]
+pub(crate) enum GenericFloatRwArray2<'py> {
+    #[pyo3(transparent, annotation = "np.ndarray[float32]")]
+    Float32(PyReadwriteArray2<'py, f32>),
+    #[pyo3(transparent, annotation = "np.ndarray[float64]")]
+    Float64(PyReadwriteArray2<'py, f64>),
+}
+
+impl<'py> TryFrom<GenericFloatRwArray2<'py>> for PyReadwriteArray2<'py, f32> {
+    type Error = ();
+
+    fn try_from(value: GenericFloatRwArray2<'py>) -> Result<Self, Self::Error> {
+        match value {
+            GenericFloatRwArray2::Float32(a) => Ok(a),
+            GenericFloatRwArray2::Float64(_) => Err(()),
+        }
+    }
+}
+
+impl<'py> TryFrom<GenericFloatRwArray2<'py>> for PyReadwriteArray2<'py, f64> {
+    type Error = ();
+
+    fn try_from(value: GenericFloatRwArray2<'py>) -> Result<Self, Self::Error> {
+        match value {
+            GenericFloatRwArray2::Float32(_) => Err(()),
+            GenericFloatRwArray2::Float64(a) => Ok(a),
         }
     }
 }


### PR DESCRIPTION
It was aimed to fix #62, but it looks like we have no performance gain for this implementations. BTW, for `__call__(out=array)` reduces performance, it looks like checking every input array has cost of ~4μs (on my laptop).