### PR TITLE
Reduce Rust-Python inter-op cost significantly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     -   id: cargo-clippy-fix
         name: cargo clippy fix
         language: rust
-        entry: cargo clippy --manifest-path=light-curve/Cargo.toml --all-targets --fix --allow-dirty
+        entry: cargo clippy --manifest-path=light-curve/Cargo.toml --all-targets --fix --allow-dirty --allow-staged
         files: \.rs
         pass_filenames: false
     -   id: cargo-clippy-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
---
+- Reduce Rust-Python inter-op cost for numpy arrays significantly. It dropped from ~4 μs per array to ~100ns. https://github.com/light-curve/light-curve-python/pull/174
 
 ### Security
 

--- a/light-curve/src/check.rs
+++ b/light-curve/src/check.rs
@@ -4,14 +4,14 @@ use itertools::Itertools;
 use light_curve_feature::Float;
 use ndarray::{ArrayView1, Zip};
 
-pub fn is_sorted<T>(a: &[T]) -> bool
+pub(crate) fn is_sorted<T>(a: &[T]) -> bool
 where
     T: PartialOrd,
 {
     a.iter().tuple_windows().all(|(a, b)| a < b)
 }
 
-pub fn check_sorted<T>(a: &[T], sorted: Option<bool>) -> Res<()>
+pub(crate) fn check_sorted<T>(a: &[T], sorted: Option<bool>) -> Res<()>
 where
     T: PartialOrd,
 {
@@ -32,7 +32,7 @@ where
     }
 }
 
-pub fn check_finite<T>(a: ArrayView1<'_, T>) -> Res<()>
+pub(crate) fn check_finite<T>(a: ArrayView1<'_, T>) -> Res<()>
 where
     T: Float,
 {
@@ -45,7 +45,7 @@ where
     }
 }
 
-pub fn check_no_nans<T>(a: ArrayView1<'_, T>) -> Res<()>
+pub(crate) fn check_no_nans<T>(a: ArrayView1<'_, T>) -> Res<()>
 where
     T: Float,
 {

--- a/light-curve/src/errors.rs
+++ b/light-curve/src/errors.rs
@@ -13,7 +13,7 @@ import_exception!(pickle, UnpicklingError);
 #[allow(clippy::enum_variant_names)]
 #[derive(Clone, Error, Debug)]
 #[error("{0}")]
-pub enum Exception {
+pub(crate) enum Exception {
     // builtins
     IndexError(String),
     NotImplementedError(String),
@@ -41,4 +41,4 @@ impl From<Exception> for PyErr {
     }
 }
 
-pub type Res<T> = Result<T, Exception>;
+pub(crate) type Res<T> = Result<T, Exception>;

--- a/light-curve/src/lib.rs
+++ b/light-curve/src/lib.rs
@@ -3,13 +3,14 @@ use features as f;
 use ln_prior::*;
 use pyo3::prelude::*;
 
+#[macro_use]
+mod np_array;
 mod check;
 mod cont_array;
 mod dmdt;
 mod errors;
 mod features;
 mod ln_prior;
-mod np_array;
 
 /// High-performance time-series feature extractor
 ///

--- a/light-curve/src/np_array.rs
+++ b/light-curve/src/np_array.rs
@@ -2,39 +2,8 @@ use crate::errors::{Exception, Res};
 
 use numpy::{Element, PyArray1, PyReadonlyArray1};
 use pyo3::prelude::*;
-use std::convert::TryFrom;
 
 pub(crate) type Arr<'a, T> = PyReadonlyArray1<'a, T>;
-
-#[derive(FromPyObject)]
-pub(crate) enum GenericFloatArray1<'a> {
-    #[pyo3(transparent, annotation = "np.ndarray[float32]")]
-    Float32(Arr<'a, f32>),
-    #[pyo3(transparent, annotation = "np.ndarray[float64]")]
-    Float64(Arr<'a, f64>),
-}
-
-impl<'a> TryFrom<GenericFloatArray1<'a>> for Arr<'a, f32> {
-    type Error = ();
-
-    fn try_from(value: GenericFloatArray1<'a>) -> Result<Self, Self::Error> {
-        match value {
-            GenericFloatArray1::Float32(a) => Ok(a),
-            GenericFloatArray1::Float64(_) => Err(()),
-        }
-    }
-}
-
-impl<'a> TryFrom<GenericFloatArray1<'a>> for Arr<'a, f64> {
-    type Error = ();
-
-    fn try_from(value: GenericFloatArray1<'a>) -> Result<Self, Self::Error> {
-        match value {
-            GenericFloatArray1::Float32(_) => Err(()),
-            GenericFloatArray1::Float64(a) => Ok(a),
-        }
-    }
-}
 
 pub(crate) trait DType {
     fn dtype_name() -> &'static str;

--- a/light-curve/src/np_array.rs
+++ b/light-curve/src/np_array.rs
@@ -1,4 +1,6 @@
-use numpy::PyReadonlyArray1;
+use crate::errors::{Exception, Res};
+
+use numpy::{Element, PyArray1, PyReadonlyArray1};
 use pyo3::prelude::*;
 use std::convert::TryFrom;
 
@@ -32,4 +34,105 @@ impl<'a> TryFrom<GenericFloatArray1<'a>> for Arr<'a, f64> {
             GenericFloatArray1::Float64(a) => Ok(a),
         }
     }
+}
+
+pub(crate) trait DType {
+    fn dtype_name() -> &'static str;
+}
+
+impl DType for f32 {
+    fn dtype_name() -> &'static str {
+        "float32"
+    }
+}
+
+impl DType for f64 {
+    fn dtype_name() -> &'static str {
+        "float64"
+    }
+}
+
+pub(crate) fn extract_matched_array<'py, T>(
+    y_name: &'static str,
+    y: &'py PyAny,
+    x_name: &'static str,
+    x: &Arr<'py, T>,
+) -> Res<Arr<'py, T>>
+where
+    T: Element + DType,
+{
+    if let Ok(y) = y.downcast::<PyArray1<T>>() {
+        let y = y.readonly();
+        if y.len() == x.len() {
+            Ok(y)
+        } else {
+            Err(Exception::ValueError(format!(
+                "Mismatched length ({}: {}, {}: {})",
+                y_name,
+                y.len(),
+                x_name,
+                x.len(),
+            )))
+        }
+    } else {
+        let y_type = y
+            .get_type()
+            .name()
+            .map(|name| {
+                if name == "ndarray" {
+                    format!(
+                        "ndarray[{}]",
+                        y.getattr("dtype")
+                            .map(|dtype| dtype
+                                .getattr("name")
+                                .map(|p| p.to_string())
+                                .unwrap_or("unknown".into()))
+                            .unwrap_or("unknown".into())
+                    )
+                } else {
+                    name.to_string()
+                }
+            })
+            .unwrap_or("unknown".into());
+        Err(Exception::TypeError(format!(
+            "Mismatched types ({}: np.ndarray[{}], {}: {})",
+            x_name,
+            T::dtype_name(),
+            y_name,
+            y_type
+        )))
+    }
+}
+
+macro_rules! dtype_dispatch {
+    ($func: tt ($first_arg:expr $(,$arg:expr)* $(,)?)) => {
+        dtype_dispatch!($func, $func, $first_arg $(,$arg)*)
+    };
+    ($f32:expr, $f64:expr, $first_arg:expr $(,)?) => {{
+        if let Ok(x32) = $first_arg.downcast::<numpy::PyArray1<f32>>() {
+            let x32 = x32.readonly();
+            let f32 = $f32;
+            f32(x32)
+        } else if let Ok(x64) = $first_arg.downcast::<numpy::PyArray1<f64>>() {
+            let x64 = x64.readonly();
+            let f64 = $f64;
+            f64(x64)
+        } else {
+            Err(crate::errors::Exception::TypeError("Unsupported dtype".into()).into())
+        }
+    }};
+    ($f32:expr, $f64:expr, $first_arg:expr $(,$arg:expr)+ $(,)?) => {{
+        let x_name = stringify!($first_arg);
+        if let Ok(x32) = $first_arg.downcast::<numpy::PyArray1<f32>>() {
+            let x32 = x32.readonly();
+            let f32 = $f32;
+            f32(x32.clone(), $(crate::np_array::extract_matched_array(stringify!($arg), $arg, x_name, &x32)?,)*)
+        } else if let Ok(x64) = $first_arg.downcast::<numpy::PyArray1<f64>>() {
+            let x64 = x64.readonly();
+            let f64 = $f64;
+            f64(x64.clone(), $(crate::np_array::extract_matched_array(stringify!($arg), $arg, x_name, &x64)?,)*)
+        } else {
+            Err(crate::errors::Exception::TypeError("Unsupported dtype".into()).into())
+        }
+    }};
 }


### PR DESCRIPTION
We use suboptimal way to cast numpy arrays to corresponding `rust-numpy` structures. Here we rework this part to achive ~50x better performance of `ObservationCount` for zero-sized input for both `__call__()` and `many()`.

See relevant discussion about `pyo3` casting performance:
https://github.com/PyO3/pyo3/discussions/2968