### PR TITLE
Keyword-only arguments and pyO3 v0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
---
+- **API breaking:** Features' `__call__()` signature changed to make `sorted=None`, `check=True` and `fill_value=None` arguments to be keyword-only
+- **API breaking:** Features' `many()` signature changed to make all but the first `lcs` arguments to be keyword-only
+- **API breaking:** `Bins` constructor signature changed to make `offset` and `window` arguments to be keyword-only
+- **API breaking:** `BazinFit` and `VillarFit` constructor signatures changed to make everything but the first `lcs` argument to be keyword-only
+- **API breaking:** `Periodogram` constructor signature changed to make all arguments to be keyword-only
+- **API breaking:** `DmDt` constructor signature changed to make all arguments but `dt` and `dm` to be keyword-only. `DmDt.from_borders` class-method constructor has all agruments to be keyword-only
+- **API breaking:** `DmDt` methods' signatures changed to make all arguments but data (like `t`, `t, m` or `lcs`) to be keyword-only
+- Bump `pyo3` 0.17.3 -> 0.18.1
+- Bump `rust-numpy` 0.17.2 -> 0.18.0
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **API breaking:** Features' `__call__()` signature changed to make `sorted=None`, `check=True` and `fill_value=None` arguments to be keyword-only
 - **API breaking:** Features' `many()` signature changed to make all but the first `lcs` arguments to be keyword-only
-- **API breaking:** `Bins` constructor signature changed to make `offset` and `window` arguments to be keyword-only
+- **API breaking:** `Bins` constructor signature changed to make `offset` and `window` arguments to be keyword-only. Please note that this for the case of Python implementation and Python version < 3.10, `Bins` still accepts positional arguments
 - **API breaking:** `BazinFit` and `VillarFit` constructor signatures changed to make everything but the first `lcs` argument to be keyword-only
 - **API breaking:** `Periodogram` constructor signature changed to make all arguments to be keyword-only
 - **API breaking:** `DmDt` constructor signature changed to make all arguments but `dt` and `dm` to be keyword-only. `DmDt.from_borders` class-method constructor has all agruments to be keyword-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **API breaking:** Features' `__call__()` signature changed to make `sorted=None`, `check=True` and `fill_value=None` arguments to be keyword-only
 - **API breaking:** Features' `many()` signature changed to make all but the first `lcs` arguments to be keyword-only
-- **API breaking:** `Bins` constructor signature changed to make `offset` and `window` arguments to be keyword-only. Please note that this for the case of Python implementation and Python version < 3.10, `Bins` still accepts positional arguments
+- **API breaking:** `Bins` constructor signature changed to make `offset` and `window` arguments to be keyword-only. For Rust implementation `__getnewargs__` is replaced with `__getnewargs_ex__`. Please note that this for the case of Python implementation and Python version < 3.10, `Bins` still accepts positional arguments
 - **API breaking:** `BazinFit` and `VillarFit` constructor signatures changed to make everything but the first `lcs` argument to be keyword-only
 - **API breaking:** `Periodogram` constructor signature changed to make all arguments to be keyword-only
-- **API breaking:** `DmDt` constructor signature changed to make all arguments but `dt` and `dm` to be keyword-only. `DmDt.from_borders` class-method constructor has all agruments to be keyword-only
+- **API breaking:** `DmDt` constructor signature changed to make all arguments but `dt` and `dm` to be keyword-only, `__getnewargs__` is replaced with `__getnewargs_ex__`. `DmDt.from_borders` class-method constructor has all agruments to be keyword-only
 - **API breaking:** `DmDt` methods' signatures changed to make all arguments but data (like `t`, `t, m` or `lcs`) to be keyword-only
 - Bump `pyo3` 0.17.3 -> 0.18.1
 - Bump `rust-numpy` 0.17.2 -> 0.18.0

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -38,17 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,9 +729,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -899,17 +888,17 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a462c1af5ba1fddec1488c4646993a23ae7931f9e170ccba23e9c7c834277797"
+checksum = "96b0fee4571867d318651c24f4a570c3f18408cf95f16ccb576b3ce85496a46e"
 dependencies = [
- "ahash",
  "libc",
  "ndarray 0.15.6",
  "num-complex 0.4.3",
  "num-integer",
  "num-traits",
  "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -998,14 +987,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+checksum = "06a3d8e8a46ab2738109347433cb7b96dffda2e4a218b03ef27090238886b147"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1015,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+checksum = "75439f995d07ddfad42b192dfcf3bc66a7ecfd8b4a1f5f6f046aa5c2c5d7677d"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1025,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "839526a5c07a17ff44823679b68add4a58004de00512a95b6c1c98a6dcac0ee5"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1035,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+checksum = "bd44cf207476c6a9760c4653559be4f206efafb924d3e4cbf2721475fc0d6cc5"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1047,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+checksum = "dc1f43d8e30460f36350d18631ccf85ded64c059829208fe680904c65bcd0a4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1223,6 +1212,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1477,12 +1472,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset",
  "scopeguard",
 ]
 
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "light-curve-python"
-version = "0.6.5"
+version = "0.7.0-alpha.0"
 dependencies = [
  "anyhow",
  "const_format",
@@ -726,15 +726,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -994,7 +985,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
- "memoffset 0.8.0",
+ "memoffset",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-curve-python"
-version = "0.6.5"
+version = "0.7.0-alpha.0"
 authors = ["Konstantin Malanchev <hombit@gmail.com>", "Anastasia Lavrukhina <lavrukhina.ad@gmail.com>"]
 description = "Feature extractor from noisy time series"
 readme = "README.md"

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -34,10 +34,10 @@ enumflags2 = { version = "0.7.5", features = ["serde"] }
 itertools = "0.10.5"
 macro_const = "0.1.0"
 ndarray = { version = "0.15.3", features = ["rayon"] }
-numpy = "0.17.2"
+numpy = "0.18.0"
 num_cpus = "1.13.0"
 num-traits = "0.2"
-pyo3 = {version = "0.17.3", features = ["extension-module"]}
+pyo3 = {version = "0.18.1", features = ["extension-module"]}
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"
 thiserror = "1.0.37"

--- a/light-curve/light_curve/light_curve_py/features/_base.py
+++ b/light-curve/light_curve/light_curve_py/features/_base.py
@@ -36,7 +36,7 @@ class BaseFeature(ABC):
 
         return t, m, sigma
 
-    def _eval_and_fill(self, t, m, sigma, fill_value):
+    def _eval_and_fill(self, t, m, sigma, *, fill_value):
         try:
             a = self._eval(t, m, sigma)
             if np.any(~np.isfinite(a)):
@@ -47,15 +47,15 @@ class BaseFeature(ABC):
                 return np.full(self.size, fill_value)
             raise e
 
-    def __call__(self, t, m, sigma=None, sorted=None, check=True, fill_value=None):
+    def __call__(self, t, m, sigma=None, *, sorted=None, check=True, fill_value=None):
         t, m, sigma = self._normalize_input(t=t, m=m, sigma=sigma, sorted=sorted, check=check)
-        return self._eval_and_fill(t, m, sigma, fill_value)
+        return self._eval_and_fill(t, m, sigma, fill_value=fill_value)
 
     @mark_experimental
     def __post_init__(self):
         pass
 
-    def many(self, lcs, sorted=None, check=True, fill_value=None, n_jobs=-1):
+    def many(self, lcs, *, sorted=None, check=True, fill_value=None, n_jobs=-1):
         """Extract features in bulk
 
         This exists for computability only and doesn't support parallel

--- a/light-curve/light_curve/light_curve_py/features/_base_meta.py
+++ b/light-curve/light_curve/light_curve_py/features/_base_meta.py
@@ -26,7 +26,7 @@ class BaseMetaFeature(BaseFeature):
     def _eval(self, t, m, sigma=None):
         raise NotImplementedError("_eval is missed for BaseMetaFeature")
 
-    def _eval_and_fill(self, t, m, sigma, fill_value):
+    def _eval_and_fill(self, t, m, sigma, *, fill_value):
         t, m, sigma = self.transform(t, m, sigma)
         return self.extractor._eval_and_fill(t, m, sigma, fill_value)
 

--- a/light-curve/light_curve/light_curve_py/features/bins.py
+++ b/light-curve/light_curve/light_curve_py/features/bins.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass
 
 import numpy as np
@@ -6,12 +7,21 @@ from scipy import ndimage
 from ._base_meta import BaseMetaFeature
 
 
+if sys.version_info >= (3, 10):
+    from dataclasses import field
+else:
+    from dataclasses import field as _field
+
+    def field(*, kw_only, **kwargs):
+        return _field(**kwargs)
+
+
 @dataclass()
 class Bins(BaseMetaFeature):
-    window: float = 1.0
-    offset: float = 0.0
+    window: float = field(default=1.0, kw_only=True)
+    offset: float = field(default=0.0, kw_only=True)
 
-    def transform(self, t, m, sigma=None, sorted=None, fill_value=None):
+    def transform(self, t, m, sigma=None, *, sorted=None, fill_value=None):
         assert self.window > 0, "Window should be a positive number."
         n = np.ceil((t[-1] - t[0]) / self.window) + 1
         j = np.arange(0, n)

--- a/light-curve/light_curve/light_curve_py/features/extractor.py
+++ b/light-curve/light_curve/light_curve_py/features/extractor.py
@@ -17,7 +17,7 @@ class _PyExtractor(BaseFeature):
         raise NotImplementedError("_eval is missed for _PyExtractor")
 
     def _eval_and_fill(self, t, m, sigma, fill_value):
-        return np.concatenate([np.atleast_1d(feature(t, m, sigma, fill_value)) for feature in self.features])
+        return np.concatenate([np.atleast_1d(feature(t, m, sigma, fill_value=fill_value)) for feature in self.features])
 
     @property
     def size(self):

--- a/light-curve/light_curve/light_curve_py/features/flux_n_not_det_before_fd.py
+++ b/light-curve/light_curve/light_curve_py/features/flux_n_not_det_before_fd.py
@@ -31,7 +31,7 @@ class FluxNNotDetBeforeFd(BaseFeature):
     signal_to_noise: float
     strictly_fainter: bool = False
 
-    def _eval(self, t, m, sigma=None, sorted=None, fill_value=None):
+    def _eval(self, t, m, sigma=None):
         detections = np.argwhere(m > self.signal_to_noise * sigma).flatten()
 
         if len(detections) == len(m):

--- a/light-curve/light_curve/light_curve_py/features/magnitude_n_not_det_before_fd.py
+++ b/light-curve/light_curve/light_curve_py/features/magnitude_n_not_det_before_fd.py
@@ -31,7 +31,7 @@ class MagnitudeNNotDetBeforeFd(BaseFeature):
     sigma_non_detection: float = np.Inf
     strictly_fainter: bool = False
 
-    def _eval(self, t, m, sigma=None, sorted=None, fill_value=None):
+    def _eval(self, t, m, sigma=None):
         detections = np.argwhere(sigma != self.sigma_non_detection).flatten()
 
         if len(detections) == len(m):

--- a/light-curve/src/ln_prior.rs
+++ b/light-curve/src/ln_prior.rs
@@ -10,20 +10,18 @@ use serde::{Deserialize, Serialize};
 ///
 /// Construct instances of this class using stand-alone functions. The constructor of this class
 /// always returns `none` variant (see `ln_prior.none()`).
-#[pyclass(module = "light_curve.light_curve_ext.ln_prior")]
+#[pyclass]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct LnPrior1D(pub lcf::LnPrior1D);
 
 #[pymethods]
 impl LnPrior1D {
     #[new]
-    #[args()]
     fn __new__() -> Self {
         Self(lcf::LnPrior1D::none())
     }
 
     /// Used by pickle.load / pickle.loads
-    #[args(state)]
     fn __setstate__(&mut self, state: &PyBytes) -> Res<()> {
         *self = serde_pickle::from_slice(state.as_bytes(), serde_pickle::DeOptions::new())
             .map_err(|err| {
@@ -35,7 +33,6 @@ impl LnPrior1D {
     }
 
     /// Used by pickle.dump / pickle.dumps
-    #[args()]
     fn __getstate__<'py>(&self, py: Python<'py>) -> Res<&'py PyBytes> {
         let vec_bytes =
             serde_pickle::to_vec(&self, serde_pickle::SerOptions::new()).map_err(|err| {
@@ -47,13 +44,11 @@ impl LnPrior1D {
     }
 
     /// Used by copy.copy
-    #[args()]
     fn __copy__(&self) -> Self {
         self.clone()
     }
 
     /// Used by copy.deepcopy
-    #[args(memo)]
     fn __deepcopy__(&self, _memo: &PyAny) -> Self {
         self.clone()
     }
@@ -64,7 +59,7 @@ impl LnPrior1D {
 /// Returns
 /// -------
 /// LnPrior1D
-#[pyfunction(text_signature = "()", module = "light_curve.light_curve_ext.ln_prior")]
+#[pyfunction]
 fn none() -> LnPrior1D {
     LnPrior1D(lcf::LnPrior1D::none())
 }
@@ -81,10 +76,7 @@ fn none() -> LnPrior1D {
 /// LnPrior1D
 ///
 /// https://en.wikipedia.org/wiki/Log-normal_distribution
-#[pyfunction(
-    text_signature = "(mu, sigma)",
-    module = "light_curve.light_curve_ext.ln_prior"
-)]
+#[pyfunction]
 fn log_normal(mu: f64, sigma: f64) -> LnPrior1D {
     LnPrior1D(lcf::LnPrior1D::log_normal(mu, sigma))
 }
@@ -101,10 +93,7 @@ fn log_normal(mu: f64, sigma: f64) -> LnPrior1D {
 /// Returns
 /// -------
 /// LnPrior1D
-#[pyfunction(
-    text_signature = "(left, right)",
-    module = "light_curve.light_curve_ext.ln_prior"
-)]
+#[pyfunction]
 fn log_uniform(left: f64, right: f64) -> LnPrior1D {
     LnPrior1D(lcf::LnPrior1D::log_uniform(left, right))
 }
@@ -119,7 +108,7 @@ fn log_uniform(left: f64, right: f64) -> LnPrior1D {
 /// Returns
 /// -------
 /// LnPrior1D
-#[pyfunction(text_signature = "(mu, sigma)", module = "light_curve.light_curve_ext")]
+#[pyfunction]
 fn normal(mu: f64, sigma: f64) -> LnPrior1D {
     LnPrior1D(lcf::LnPrior1D::normal(mu, sigma))
 }
@@ -136,10 +125,7 @@ fn normal(mu: f64, sigma: f64) -> LnPrior1D {
 /// Returns
 /// -------
 /// LnPrior1D
-#[pyfunction(
-    text_signature = "(left, right)",
-    module = "light_curve.light_curve_ext"
-)]
+#[pyfunction]
 fn uniform(left: f64, right: f64) -> LnPrior1D {
     LnPrior1D(lcf::LnPrior1D::uniform(left, right))
 }
@@ -153,7 +139,7 @@ fn uniform(left: f64, right: f64) -> LnPrior1D {
 ///     mixed logarithm of prior is
 ///     ln(sum(norm_weight_i * exp(ln_prior_i(x))))
 ///     where norm_weight_i = weight_i / sum(weight_j)
-#[pyfunction(text_signature = "mix", module = "light_curve.light_curve_ext")]
+#[pyfunction]
 fn mix(mix: Vec<(f64, LnPrior1D)>) -> LnPrior1D {
     let priors = mix
         .into_iter()

--- a/light-curve/src/ln_prior.rs
+++ b/light-curve/src/ln_prior.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Construct instances of this class using stand-alone functions. The constructor of this class
 /// always returns `none` variant (see `ln_prior.none()`).
-#[pyclass]
+#[pyclass(module = "light_curve.light_curve_ext.ln_prior")]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct LnPrior1D(pub lcf::LnPrior1D);
 

--- a/light-curve/tests/test_w_bench.py
+++ b/light-curve/tests/test_w_bench.py
@@ -104,6 +104,7 @@ class _Test:
     name = None
     # Argument tuple for the feature constructor
     args = ()
+    kwargs = {}
 
     py_feature = None
 
@@ -120,9 +121,9 @@ class _Test:
     phot_types = Data.phot_type_choices
 
     def setup_method(self):
-        self.rust = getattr(lc_ext, self.name)(*self.args)
+        self.rust = getattr(lc_ext, self.name)(*self.args, **self.kwargs)
         try:
-            self.py_feature = getattr(lc_py, self.name)(*self.args)
+            self.py_feature = getattr(lc_py, self.name)(*self.args, **self.kwargs)
         except AttributeError:
             pass
 

--- a/light-curve/tests/test_w_bench.py
+++ b/light-curve/tests/test_w_bench.py
@@ -292,7 +292,8 @@ if lc_ext._built_with_gsl:
 
     class TestBazinFit(_Test):
         name = "BazinFit"
-        args = ("lmsder", None, 20)
+        args = ("lmsder",)
+        kwargs = {"lmsder_niter": 20}
         rtol = 1e-4  # Precision used in the feature implementation
 
         add_to_all_features = False  # in All* random data is used


### PR DESCRIPTION
**This is breaking change**

It still requires some work to implement keyword-only arguments in tests.