### PR TITLE
Replace pytest-markdown with markdown-pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `pyO3` 0.18.1 -> 0.18.2
 - Most of the parametric features have default values for their parameters now, which, due to `pyO3` limitations, are not presented in the signatures, but documented in the docstrings. It also makes Python and Rust implementations more consistent https://github.com/light-curve/light-curve-python/issues/194 https://github.com/light-curve/light-curve-python/pull/195
+- Development: switch from `pytest-markdown` to `markdown-pytest` which allowed us to use up-to-date pytest
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Binary wheels for x86_64 Windows built with no Ceres nor GSL features https://github.com/light-curve/light-curve-python/issues/12 https://github.com/light-curve/light-curve-python/pull/185
 - CI: code coverage with `codecov` https://github.com/light-curve/light-curve-python/pull/197
+- Development: now project has extras for testing (`test`) and development (`dev`) https://github.com/light-curve/light-curve-python/pull/197
 
 ### Changed
 
 - Bump `pyO3` 0.18.1 -> 0.18.2
 - Most of the parametric features have default values for their parameters now, which, due to `pyO3` limitations, are not presented in the signatures, but documented in the docstrings. It also makes Python and Rust implementations more consistent https://github.com/light-curve/light-curve-python/issues/194 https://github.com/light-curve/light-curve-python/pull/195
-- Development: switch from `pytest-markdown` to `markdown-pytest` which allowed us to use up-to-date pytest
+- Development: switch from `pytest-markdown` to `markdown-pytest` which allowed us to use up-to-date pytest https://github.com/light-curve/light-curve-python/pull/198
 
 ### Deprecated
 

--- a/light-curve/README.md
+++ b/light-curve/README.md
@@ -42,6 +42,7 @@ twine upload wheelhouse/*.whl
 Most of the classes implement various feature evaluators useful for light-curve based
 astrophysical source classification and characterisation.
 
+<!-- name: test_feature_evaluators_basic -->
 ```python
 import light_curve as lc
 import numpy as np
@@ -83,6 +84,7 @@ Note that if your inputs are not valid and are not validated by
 `sorted=None` and `check=True` (default values) then all kind of bad things could happen.
 
 Print feature classes list
+<!-- name: test_feature_evaluators_list -->
 ```python
 import light_curve as lc
 
@@ -90,6 +92,7 @@ print([x for x in dir(lc) if hasattr(getattr(lc, x), "names")])
 ```
 
 Read feature docs
+<!-- name: test_feature_evaluators_help -->
 ```python
 import light_curve as lc
 
@@ -105,6 +108,7 @@ However, the Python implementation provides some new feature extractors you can 
 
 You can manually use extractors from both implementations:
 
+<!-- name: test_experimental_extractors -->
 ```python
 import numpy as np
 from numpy.testing import assert_allclose
@@ -417,6 +421,7 @@ See benchmarks' descriptions in more details in ["Performant feature extraction 
 
 Class `DmDt` provides dm–dt mapper (based on [Mahabal et al. 2011](https://ui.adsabs.harvard.edu/abs/2011BASI...39..387M/abstract), [Soraisam et al. 2020](https://ui.adsabs.harvard.edu/abs/2020ApJ...892..112S/abstract)). It is a Python wrapper for [`light-curve-dmdt` Rust crate](https://crates.io/crates/light-curve-dmdt).
 
+<!-- name: test_dmdt -->
 ```python
 import numpy as np
 from light_curve import DmDt

--- a/light-curve/pyproject.toml
+++ b/light-curve/pyproject.toml
@@ -28,7 +28,7 @@ test = [
     "pandas",
     "pytest",
     "pytest-benchmark",
-    "pytest-markdown",
+    "markdown-pytest",
     "pytest-subtests",
 ]
 dev = [
@@ -100,7 +100,7 @@ minversion = "6.0"
 addopts = "-ra --import-mode=append --benchmark-min-time=0.1 --benchmark-max-time=5.0 --benchmark-sort=mean --benchmark-disable"
 testpaths = [
     "tests/",
-    "README.md", # requires pytest-markdown
+    "README.md", # requires markdown-pytest
 ]
 
 [tool.tox]
@@ -127,7 +127,7 @@ test-command = "pytest {package}/README.md {package}/light_curve/ {package}/test
 test-requires = [
     "pytest",
     "pytest-benchmark",
-    "pytest-markdown",
+    "markdown-pytest",
     "pytest-subtests",
     "numpy",
     "scipy",


### PR DESCRIPTION
`pytest-markdown` requires pytest 6, while `markdown-pytest` works with up-to-date pytest 7