### PR TITLE
abi3-py311

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
             arch: ppc64le
           - os: windows-2019
             arch: x86_64
-          # We need a single interpreter for ABI, so we use py310 only
+          # We need a single interpreter for ABI, so we use py311 only
           - abi3: true
             interpreter: cp37
           - abi3: true
@@ -101,7 +101,7 @@ jobs:
           - abi3: true
             interpreter: cp39
           - abi3: true
-            interpreter: cp311
+            interpreter: cp310
           - abi3: true
             interpreter: pp37
           - abi3: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Breaking change in experimental features** Multiband support is introduced for features implemented in Python. It changes class inheritance interface in a backward-incompatible way
+- **Breaking change in experimental features**: Multiband support is introduced for features implemented in Python. It changes class inheritance interface in a backward-incompatible way
 - `light-curve[full]` extras which installs all optional Python dependencies required by experimental features
 - Experimental `RainbowFit` feature for fitting multiband light curves with a single model, Russeil+23 in prep. It requires Python 3.8 or later because of `iminuit` dependency
 - Optional `iminuit>=2,<3` dependency (included into `[full]`) for `RainbowFit` feature
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking change in experimental features** `scipy` dependency is now optional for experimental features implemented in Python
-- **Breaking change in experimental features** All experimental features implemented in Python require keyword-only arguments in their constructors. Also, all names of the arguments are changed to be the same as for Rust features
+- **Breaking change in experimental features**: All experimental features implemented in Python require keyword-only arguments in their constructors. Also, all names of the arguments are changed to be the same as for Rust features
+- **Build breaking**: "abi3-py310" Cargo feature is replaced with "abi3-py311". "abi3" feature is now linked to "abi3-py311" feature. This is because our aim with ABI is to support future versions of Python
 - Bump `pyO3` 0.18.3 -> 0.19.1, it simplified signature generations for classes https://github.com/light-curve/light-curve-python/pull/230
 - Bump `rust-numpy` 0.18.0 -> 0.19.0 https://github.com/light-curve/light-curve-python/pull/230
 - Bump `thiserror` 1.0.41 -> 1.0.48 https://github.com/light-curve/light-curve-python/pull/242

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb88ae05f306b4bfcde40ac4a51dc0b05936a9207a4b75b798c7729c4258a59"
+checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554db24f0b3c180a9c0b1268f91287ab3f17c162e15b54caaae5a6b3773396b0"
+checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922ede8759e8600ad4da3195ae41259654b9c55da4f7eec84a0ccc7d067a70a4"
+checksum = "e53cee42e77ebe256066ba8aa77eff722b3bb91f3419177cf4cd0f304d3284d9"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5caec6a1dd355964a841fcbeeb1b89fe4146c87295573f94228911af3cc5a2"
+checksum = "dfeb4c99597e136528c6dd7d5e3de5434d1ceaf487436a3f03b2d56b6fc9efd1"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b78ccbb160db1556cdb6fd96c50334c5d4ec44dc5e0a968d0a1208fa0efa8b"
+checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -19,8 +19,8 @@ codegen-units = 1
 
 [features]
 default = ["ceres-source", "fftw-source", "gsl"]
-abi3 = ["abi3-py310"]
-abi3-py310 = ["pyo3/abi3-py310"]
+abi3 = ["abi3-py311"]
+abi3-py311 = ["pyo3/abi3-py311"]
 ceres-source = ["light-curve-feature/ceres-source"]
 ceres-system = ["light-curve-feature/ceres-system"]
 fftw-source = ["light-curve-feature/fftw-source"]
@@ -42,7 +42,7 @@ ndarray = { version = "0.15.3", features = ["rayon"] }
 numpy = "0.19.0"
 num_cpus = "1.13.0"
 num-traits = "0.2"
-pyo3 = {version = "0.19.1", features = ["extension-module", "multiple-pymethods"]}
+pyo3 = {version = "0.19.2", features = ["extension-module", "multiple-pymethods"]}
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"
 thiserror = "1.0.48"


### PR DESCRIPTION
Replaces "abi3-py310" Cargo  feature with "abi3-py311". This is because of our strategy to use the most recent ABI3 available for future Python releases while still providing version-specific wheels for all currently supported releases