### PR TITLE
Patch astropy 6 for feets

### DIFF
--- a/light-curve/tests/conftest.py
+++ b/light-curve/tests/conftest.py
@@ -1,0 +1,21 @@
+import sys
+
+
+def patch_astropy_for_feets():
+    """Feets is incompatible with astropy v6.0 because of backward incompatible
+    changes in the subpackage structure. This function monkey patches astropy
+    to make it compatible with feets.
+    """
+    import importlib
+    from importlib.metadata import version
+
+    if int(version("astropy").split(".")[0]) < 6:
+        return
+
+    lombscargle = importlib.import_module("astropy.timeseries.periodograms.lombscargle")
+    sys.modules["astropy.stats.lombscargle"] = lombscargle
+
+
+# Astropy 6 is py3.9+, importlib.metadata is py3.8+
+if sys.version_info >= (3, 8):
+    patch_astropy_for_feets()


### PR DESCRIPTION
We use `feets` library for testing and benchmarking, but last `astropy` release broke it. `astropy` changed module structure and `feets` fails on import. This PR introduces a monkey-patch of `astropy` to make `feets` happy.