### PR TITLE
Improve Rainbow fitting

### DIFF
--- a/light-curve/light_curve/light_curve_py/features/_base.py
+++ b/light-curve/light_curve/light_curve_py/features/_base.py
@@ -37,7 +37,7 @@ class BaseMultiBandFeature(ABC):
             if np.any(~np.isfinite(a)):
                 raise ValueError
             return a
-        except (ValueError, ZeroDivisionError) as e:
+        except (ValueError, ZeroDivisionError, RuntimeError) as e:
             if fill_value is not None:
                 return np.full(self.size, fill_value)
             raise e
@@ -142,7 +142,7 @@ class BaseSingleBandFeature(BaseMultiBandFeature):
             if np.any(~np.isfinite(a)):
                 raise ValueError
             return a
-        except (ValueError, ZeroDivisionError) as e:
+        except (ValueError, ZeroDivisionError, RuntimeError) as e:
             if fill_value is not None:
                 return np.full(self.size_single_band, fill_value)
             raise e

--- a/light-curve/light_curve/light_curve_py/features/rainbow/__init__.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/__init__.py
@@ -1,2 +1,3 @@
 from .bazin import *
 from .rising import *
+from .symmetric import *

--- a/light-curve/light_curve/light_curve_py/features/rainbow/_scaler.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/_scaler.py
@@ -47,6 +47,10 @@ class Scaler:
     def undo_scale(self, x):
         return x * self.scale
 
+    def reset_shift(self):
+        """Resets scaler shift to zero, keeping only the scale"""
+        self.shift *= 0
+
 
 @dataclass()
 class MultiBandScaler(Scaler):
@@ -83,3 +87,10 @@ class MultiBandScaler(Scaler):
 
     def undo_shift_scale_band(self, x, band):
         return x * self.per_band_scale[band] + self.per_band_shift[band]
+
+    def reset_shift(self):
+        """Resets scaler shift to zero, keeping only the scale"""
+        for _ in self.per_band_shift:
+            self.per_band_shift[_] = 0
+
+        super().reset_shift()

--- a/light-curve/light_curve/light_curve_py/features/rainbow/_scaler.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/_scaler.py
@@ -90,7 +90,7 @@ class MultiBandScaler(Scaler):
 
     def reset_shift(self):
         """Resets scaler shift to zero, keeping only the scale"""
-        for _ in self.per_band_shift:
-            self.per_band_shift[_] = 0
+        for band in self.per_band_shift:
+            self.per_band_shift[band] = 0
 
         super().reset_shift()

--- a/light-curve/light_curve/light_curve_py/features/rainbow/symmetric.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/symmetric.py
@@ -1,0 +1,200 @@
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from light_curve.light_curve_py.features.rainbow._base import BaseRainbowFit
+from light_curve.light_curve_py.features.rainbow._scaler import MultiBandScaler, Scaler
+from light_curve.light_curve_py.dataclass_field import dataclass_field
+
+__all__ = ["RainbowSymmetricFit"]
+
+
+@dataclass()
+class RainbowSymmetricFit(BaseRainbowFit):
+    """Multiband blackbody fit to the light curve using symmetric form of Bazin function
+
+    Note, that `m` and corresponded `sigma` are assumed to be flux densities.
+
+    Based on Russeil et al. 2023, arXiv:2310.02916.
+
+    Parameters
+    ----------
+    band_wave_cm : dict
+        Dictionary of band names and their effective wavelengths in cm.
+
+    with_baseline : bool, optional
+        Whether to include an offset in the fit, individual for each band.
+        If it is true, one more fit paramter per passband is added -
+        the additive constant with the same units as input flux.
+
+    with_temperature_evolution : bool, optional
+        Whether to include temperature evolution in the fit
+
+    with_rising_only : bool, optional
+        If false, only rising part of the Bazin function is used, making
+        it effectively a sigmoid function
+
+    Methods
+    -------
+    __call__(t, m, sigma, band, *, sorted=False, check=True, fill_value=None)
+        Evaluate the feature. Positional arguments are numpy arrays of the same length,
+        `band` must consist of the same strings as keys in `band_wave_cm`. If `sorted` is True,
+        `t` must be sorted in ascending order. If `check` is True, the input is checked for
+        NaNs and Infs. If `fill_value` is not None, it is used to fill the output array if
+        the feature cannot be evaluated.
+
+    model(t, band, *params)
+        Evaluate Rainbow model on the given arrays of times and bands. `*params` are
+        fit parameters, basically the output of `__call__` method but without the last
+        parameter (reduced Chi^2 of the fit). See parameter names in the `.name` attribute.
+    """
+
+    with_temperature_evolution: bool = dataclass_field(default=True, kw_only=True)
+    """Whether to include a temperature evolution in the fit."""
+    with_rise_only: bool = dataclass_field(default=False, kw_only=True)
+    """Whether to use sigmoid (rising part only) bolometric function in the fit."""
+
+    @staticmethod
+    def _common_parameter_names() -> List[str]:
+        return ["reference_time"]
+
+    def _bolometric_parameter_names(self) -> List[str]:
+        if self.with_rise_only:
+            return ["amplitude", "rise_time"]
+        else:
+            return ["amplitude", "rise_time", "fall_time"]
+
+    def _temperature_parameter_names(self) -> List[str]:
+        if self.with_temperature_evolution:
+            return ["Tmin", "Tmax", "k_sig"]
+        else:
+            return ["Tmin"]
+
+    def bol_func(self, t, params):
+        if self.with_rise_only:
+            t0, amplitude, rise_time = params[self.p.all_bol_idx]
+        else:
+            t0, amplitude, rise_time, fall_time = params[self.p.all_bol_idx]
+        dt = t - t0
+        result = np.zeros_like(dt)
+
+        # To avoid numerical overflows, let's only compute the exponents not too far from t0
+        if self.with_rise_only:
+            idx = (dt > -100*rise_time)
+            result[idx] = amplitude / (np.exp(-dt[idx] / rise_time) + 1)
+        else:
+            idx = (dt > -100*rise_time) & (dt < 100*fall_time)
+            result[idx] = amplitude / (np.exp(-dt[idx] / rise_time) + np.exp(dt[idx] / fall_time))
+
+        return result
+
+    def temp_func(self, t, params):
+        if self.with_temperature_evolution:
+            t0, T_min, T_max, k_sig = params[self.p.all_temp_idx]
+            dt = t - t0
+
+            result = np.zeros_like(dt)
+
+            # To avoid numerical overflows, let's only compute the exponent not too far from t0
+            idx1 = dt <= -100*k_sig
+            idx2 = (dt > -100*k_sig) & (dt < 100*k_sig)
+            idx3 = dt >= 100*k_sig
+
+            result[idx1] = T_min
+            result[idx2] = T_min + (T_max - T_min) / (1.0 + np.exp(dt[idx2] / k_sig))
+            result[idx3] = T_max
+        else:
+            t0, T_min = params[self.p.all_temp_idx]
+
+            return T_min
+
+    def _normalize_bolometric_flux(self, params) -> None:
+        # Internally we use amplitude of F_bol / <nu> instead of F_bol.
+        # It makes amplitude to be in the same units and the same order as
+        # the baselines and input fluxes.
+        params[self.p.amplitude] /= self.average_nu
+
+    def _denormalize_bolometric_flux(self, params) -> None:
+        params[self.p.amplitude] *= self.average_nu
+
+    def _unscale_parameters(self, params, t_scaler: Scaler, m_scaler: MultiBandScaler) -> None:
+        self._denormalize_bolometric_flux(params)
+
+        t0 = params[self.p.reference_time]
+        t0 = t_scaler.undo_shift_scale(t0)
+        params[self.p.reference_time] = t0
+
+        if self.with_rise_only:
+            amplitude, rise_time = params[self.p.bol_idx]
+            amplitude = m_scaler.undo_scale(amplitude)
+            rise_time = t_scaler.undo_scale(rise_time)
+            params[self.p.bol_idx] = amplitude, rise_time
+        else:
+            amplitude, rise_time, fall_time = params[self.p.bol_idx]
+            amplitude = m_scaler.undo_scale(amplitude)
+            rise_time = t_scaler.undo_scale(rise_time)
+            fall_time = t_scaler.undo_scale(fall_time)
+            params[self.p.bol_idx] = amplitude, rise_time, fall_time
+
+        if self.with_temperature_evolution:
+            T_min, T_max, k_sig = params[self.p.temp_idx]
+            k_sig = t_scaler.undo_scale(k_sig)
+            params[self.p.temp_idx] = T_min, T_max, k_sig
+
+    def _initial_guesses(self, t, m, band) -> Dict[str, float]:
+        t_rise = 0.1
+        t_fall = 0.1
+
+        # The amplitude here does not actually correspond to the amplitude of m values!
+        if self.with_baseline:
+            A = np.ptp(m)
+        else:
+            A = np.max(m)
+
+        params = {}
+
+        # Why do we have to strictly follow the order of parameters here?..
+        params["reference_time"] = t[np.argmax(m)]
+        params["amplitude"] = A
+        params["rise_time"] = t_rise
+
+        if not self.with_rise_only:
+            params['fall_time'] = t_fall
+
+        params['Tmin'] = 7000.0
+
+        if self.with_temperature_evolution:
+            params['Tmax'] = 0.0
+            params['k_sig'] = 1.0
+
+        return params
+
+    def _limits(self, t, m, band) -> Dict[str, Tuple[float, float]]:
+        t_amplitude = np.ptp(t)
+        if self.with_baseline:
+            m_amplitude = np.ptp(m)
+        else:
+            m_amplitude = np.max(m)
+
+        limits = {}
+
+        # Why do we have to strictly follow the order of parameters here?..
+        limits["reference_time"] = (np.min(t) - 10 * t_amplitude, np.max(t) + 10 * t_amplitude)
+        limits["amplitude"] = (0.0, 10 * m_amplitude)
+        limits["rise_time"] = (1e-4, 10 * t_amplitude)
+
+        if not self.with_rise_only:
+            limits['fall_time'] = (1e-4, 10 * t_amplitude)
+
+        limits['Tmin'] = (1e2, 1e6) # K
+
+        if self.with_temperature_evolution:
+            limits['Tmax'] = (1e2, 1e6) # K
+            limits['k_sig'] = (1e-4, 10.0 * t_amplitude)
+
+        return limits
+
+    def _baseline_initial_guesses(self, t, m, band) -> Dict[str, float]:
+        """Initial guesses for the baseline parameters."""
+        return {self.p.baseline_parameter_name(b): np.median(m[band == b]) for b in self.bands.names}

--- a/light-curve/light_curve/light_curve_py/features/rainbow/symmetric.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/symmetric.py
@@ -109,10 +109,10 @@ class RainbowSymmetricFit(BaseRainbowFit):
             result[idx3] = T_max
 
             return result
-        else:
-            t0, T_min = params[self.p.all_temp_idx]
 
-            return T_min
+        t0, T_min = params[self.p.all_temp_idx]
+
+        return T_min
 
     def _normalize_bolometric_flux(self, params) -> None:
         # Internally we use amplitude of F_bol / <nu> instead of F_bol.
@@ -214,7 +214,7 @@ class RainbowSymmetricFit(BaseRainbowFit):
 
             # It is not, strictly speaking, defined for rising only
             return t0
-        else:
-            t0, amplitude, rise_time, fall_time = params[self.p.all_bol_idx]
 
-            return t0 + np.log(fall_time / rise_time) * rise_time * fall_time / (rise_time + fall_time)
+        t0, amplitude, rise_time, fall_time = params[self.p.all_bol_idx]
+
+        return t0 + np.log(fall_time / rise_time) * rise_time * fall_time / (rise_time + fall_time)

--- a/light-curve/light_curve/light_curve_py/features/rainbow/symmetric.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/symmetric.py
@@ -3,9 +3,9 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 
+from light_curve.light_curve_py.dataclass_field import dataclass_field
 from light_curve.light_curve_py.features.rainbow._base import BaseRainbowFit
 from light_curve.light_curve_py.features.rainbow._scaler import MultiBandScaler, Scaler
-from light_curve.light_curve_py.dataclass_field import dataclass_field
 
 __all__ = ["RainbowSymmetricFit"]
 
@@ -84,10 +84,10 @@ class RainbowSymmetricFit(BaseRainbowFit):
 
         # To avoid numerical overflows, let's only compute the exponents not too far from t0
         if self.with_rise_only:
-            idx = (dt > -100*rise_time)
+            idx = dt > -100 * rise_time
             result[idx] = amplitude / (np.exp(-dt[idx] / rise_time) + 1)
         else:
-            idx = (dt > -100*rise_time) & (dt < 100*fall_time)
+            idx = (dt > -100 * rise_time) & (dt < 100 * fall_time)
             result[idx] = amplitude / (np.exp(-dt[idx] / rise_time) + np.exp(dt[idx] / fall_time))
 
         return result
@@ -100,9 +100,9 @@ class RainbowSymmetricFit(BaseRainbowFit):
             result = np.zeros_like(dt)
 
             # To avoid numerical overflows, let's only compute the exponent not too far from t0
-            idx1 = dt <= -100*k_sig
-            idx2 = (dt > -100*k_sig) & (dt < 100*k_sig)
-            idx3 = dt >= 100*k_sig
+            idx1 = dt <= -100 * k_sig
+            idx2 = (dt > -100 * k_sig) & (dt < 100 * k_sig)
+            idx3 = dt >= 100 * k_sig
 
             result[idx1] = T_min
             result[idx2] = T_min + (T_max - T_min) / (1.0 + np.exp(dt[idx2] / k_sig))
@@ -168,13 +168,13 @@ class RainbowSymmetricFit(BaseRainbowFit):
         params["rise_time"] = t_rise
 
         if not self.with_rise_only:
-            params['fall_time'] = t_fall
+            params["fall_time"] = t_fall
 
-        params['Tmin'] = 7000.0
+        params["Tmin"] = 7000.0
 
         if self.with_temperature_evolution:
-            params['Tmax'] = 10000.0
-            params['k_sig'] = 1.0
+            params["Tmax"] = 10000.0
+            params["k_sig"] = 1.0
 
         return params
 
@@ -193,13 +193,13 @@ class RainbowSymmetricFit(BaseRainbowFit):
         limits["rise_time"] = (1e-4, 10 * t_amplitude)
 
         if not self.with_rise_only:
-            limits['fall_time'] = (1e-4, 10 * t_amplitude)
+            limits["fall_time"] = (1e-4, 10 * t_amplitude)
 
-        limits['Tmin'] = (1e2, 1e6) # K
+        limits["Tmin"] = (1e2, 1e6)  # K
 
         if self.with_temperature_evolution:
-            limits['Tmax'] = (1e2, 1e6) # K
-            limits['k_sig'] = (1e-4, 10.0 * t_amplitude)
+            limits["Tmax"] = (1e2, 1e6)  # K
+            limits["k_sig"] = (1e-4, 10.0 * t_amplitude)
 
         return limits
 

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -64,12 +64,12 @@ def test_noisy_with_baseline():
     amplitude = 1.0
     rise_time = 10.0
     fall_time = 30.0
-    Tmin = 5e3
-    delta_T = 10e3
-    k_sig = 4.0
+    Tmin = 10e3
+    delta_T = 5e3
+    k_sig = 10.0
     baselines = {b: rng.exponential(scale=3 * amplitude / average_nu) for b in band_wave_aa}
 
-    t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * fall_time, 1000))
+    t = np.sort(rng.uniform(reference_time - 5 * rise_time, reference_time + 5 * fall_time, 1000))
     band = rng.choice(list(band_wave_aa), size=len(t))
     waves = np.array([band_wave_aa[b] for b in band])
 

--- a/light-curve/tests/light_curve_py/features/test_rainbow_symmetric.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow_symmetric.py
@@ -81,6 +81,7 @@ def test_noisy_with_baseline():
 
     np.testing.assert_allclose(actual, expected, rtol=0.1)
 
+
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
 def test_noisy_without_temperature_evolution():
     rng = np.random.default_rng(0)
@@ -114,6 +115,7 @@ def test_noisy_without_temperature_evolution():
     actual = feature(t, flux, sigma=flux_err, band=band)
 
     np.testing.assert_allclose(actual, expected, rtol=0.1)
+
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
 def test_noisy_with_rise_only():
@@ -150,6 +152,7 @@ def test_noisy_with_rise_only():
 
     np.testing.assert_allclose(actual, expected, rtol=0.1)
 
+
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
 def test_noisy_with_rise_only_notemp():
     rng = np.random.default_rng(0)
@@ -177,7 +180,9 @@ def test_noisy_with_rise_only_notemp():
     flux_err = 0.1 * np.sqrt(flux * np.min(flux) / 5.0)
     flux += rng.normal(0.0, flux_err)
 
-    feature = RainbowSymmetricFit.from_angstrom(band_wave_aa, with_baseline=True, with_rise_only=True, with_temperature_evolution=False)
+    feature = RainbowSymmetricFit.from_angstrom(
+        band_wave_aa, with_baseline=True, with_rise_only=True, with_temperature_evolution=False
+    )
 
     expected = [reference_time, amplitude, rise_time, Tmin, *baselines.values(), 1.0]
     actual = feature(t, flux, sigma=flux_err, band=band)

--- a/light-curve/tests/light_curve_py/features/test_rainbow_symmetric.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow_symmetric.py
@@ -164,7 +164,6 @@ def test_noisy_with_rise_only_notemp():
     amplitude = 1.0
     rise_time = 10.0
     Tmin = 10e3
-    k_sig = 4.0
     baselines = {b: rng.exponential(scale=3 * amplitude / average_nu) for b in band_wave_aa}
 
     t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * rise_time, 1000))

--- a/light-curve/tests/light_curve_py/features/test_rainbow_symmetric.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow_symmetric.py
@@ -1,0 +1,185 @@
+import sys
+
+import numpy as np
+import pytest
+
+from light_curve.light_curve_py import RainbowSymmetricFit
+
+
+def bb_nu(wave_aa, T):
+    nu = 3e10 / (wave_aa * 1e-8)
+    return 2 * 6.626e-27 * nu**3 / 3e10**2 / np.expm1(6.626e-27 * nu / (1.38e-16 * T))
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
+def test_noisy_no_baseline():
+    rng = np.random.default_rng(0)
+
+    band_wave_aa = {"g": 4770.0, "r": 6231.0, "i": 7625.0, "z": 9134.0}
+
+    reference_time = 60000.0
+    amplitude = 1.0
+    rise_time = 5.0
+    fall_time = 30.0
+    Tmin = 5e3
+    Tmax = 15e3
+    k_sig = 4.0
+
+    t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * fall_time, 1000))
+    band = rng.choice(list(band_wave_aa), size=len(t))
+    waves = np.array([band_wave_aa[b] for b in band])
+
+    temp = Tmin + (Tmax - Tmin) / (1.0 + np.exp((t - reference_time) / k_sig))
+    lum = amplitude / (np.exp(-(t - reference_time) / rise_time) + np.exp((t - reference_time) / fall_time))
+
+    flux = np.pi * bb_nu(waves, temp) / (5.67e-5 * temp**4) * lum
+    # S/N = 5 for minimum flux, scale for Poisson noise
+    flux_err = np.sqrt(flux * np.min(flux) / 5.0)
+    flux += rng.normal(0.0, flux_err)
+
+    feature = RainbowSymmetricFit.from_angstrom(band_wave_aa, with_baseline=False)
+
+    expected = [reference_time, amplitude, rise_time, fall_time, Tmin, Tmax, k_sig, 1.0]
+    actual = feature(t, flux, sigma=flux_err, band=band)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.1)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
+def test_noisy_with_baseline():
+    rng = np.random.default_rng(0)
+
+    band_wave_aa = {"g": 4770.0, "r": 6231.0, "i": 7625.0, "z": 9134.0}
+    average_nu = np.mean([3e10 / (w * 1e-8) for w in band_wave_aa.values()])
+
+    reference_time = 60000.0
+    amplitude = 1.0
+    rise_time = 10.0
+    fall_time = 30.0
+    Tmin = 5e3
+    Tmax = 15e3
+    k_sig = 4.0
+    baselines = {b: rng.exponential(scale=3 * amplitude / average_nu) for b in band_wave_aa}
+
+    t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * fall_time, 1000))
+    band = rng.choice(list(band_wave_aa), size=len(t))
+    waves = np.array([band_wave_aa[b] for b in band])
+
+    temp = Tmin + (Tmax - Tmin) / (1.0 + np.exp((t - reference_time) / k_sig))
+    lum = amplitude / (np.exp(-(t - reference_time) / rise_time) + np.exp((t - reference_time) / fall_time))
+
+    flux = np.pi * bb_nu(waves, temp) / (5.67e-5 * temp**4) * lum + np.array([baselines[b] for b in band])
+    # S/N = 5 for minimum flux, scale for Poisson noise
+    # We make noise a bit smaller because the optimization is not perfect
+    flux_err = 0.1 * np.sqrt(flux * np.min(flux) / 5.0)
+    flux += rng.normal(0.0, flux_err)
+
+    feature = RainbowSymmetricFit.from_angstrom(band_wave_aa, with_baseline=True)
+
+    expected = [reference_time, amplitude, rise_time, fall_time, Tmin, Tmax, k_sig, *baselines.values(), 1.0]
+    actual = feature(t, flux, sigma=flux_err, band=band)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.1)
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
+def test_noisy_without_temperature_evolution():
+    rng = np.random.default_rng(0)
+
+    band_wave_aa = {"g": 4770.0, "r": 6231.0, "i": 7625.0, "z": 9134.0}
+    average_nu = np.mean([3e10 / (w * 1e-8) for w in band_wave_aa.values()])
+
+    reference_time = 60000.0
+    amplitude = 1.0
+    rise_time = 10.0
+    fall_time = 30.0
+    Tmin = 10e3
+    baselines = {b: rng.exponential(scale=3 * amplitude / average_nu) for b in band_wave_aa}
+
+    t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * fall_time, 1000))
+    band = rng.choice(list(band_wave_aa), size=len(t))
+    waves = np.array([band_wave_aa[b] for b in band])
+
+    temp = Tmin
+    lum = amplitude / (np.exp(-(t - reference_time) / rise_time) + np.exp((t - reference_time) / fall_time))
+
+    flux = np.pi * bb_nu(waves, temp) / (5.67e-5 * temp**4) * lum + np.array([baselines[b] for b in band])
+    # S/N = 5 for minimum flux, scale for Poisson noise
+    # We make noise a bit smaller because the optimization is not perfect
+    flux_err = 0.1 * np.sqrt(flux * np.min(flux) / 5.0)
+    flux += rng.normal(0.0, flux_err)
+
+    feature = RainbowSymmetricFit.from_angstrom(band_wave_aa, with_baseline=True, with_temperature_evolution=False)
+
+    expected = [reference_time, amplitude, rise_time, fall_time, Tmin, *baselines.values(), 1.0]
+    actual = feature(t, flux, sigma=flux_err, band=band)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.1)
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
+def test_noisy_with_rise_only():
+    rng = np.random.default_rng(0)
+
+    band_wave_aa = {"g": 4770.0, "r": 6231.0, "i": 7625.0, "z": 9134.0}
+    average_nu = np.mean([3e10 / (w * 1e-8) for w in band_wave_aa.values()])
+
+    reference_time = 60000.0
+    amplitude = 1.0
+    rise_time = 10.0
+    Tmin = 5e3
+    Tmax = 15e3
+    k_sig = 4.0
+    baselines = {b: rng.exponential(scale=3 * amplitude / average_nu) for b in band_wave_aa}
+
+    t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * rise_time, 1000))
+    band = rng.choice(list(band_wave_aa), size=len(t))
+    waves = np.array([band_wave_aa[b] for b in band])
+
+    temp = Tmin + (Tmax - Tmin) / (1.0 + np.exp((t - reference_time) / k_sig))
+    lum = amplitude / (np.exp(-(t - reference_time) / rise_time) + 1)
+
+    flux = np.pi * bb_nu(waves, temp) / (5.67e-5 * temp**4) * lum + np.array([baselines[b] for b in band])
+    # S/N = 5 for minimum flux, scale for Poisson noise
+    # We make noise a bit smaller because the optimization is not perfect
+    flux_err = 0.1 * np.sqrt(flux * np.min(flux) / 5.0)
+    flux += rng.normal(0.0, flux_err)
+
+    feature = RainbowSymmetricFit.from_angstrom(band_wave_aa, with_baseline=True, with_rise_only=True)
+
+    expected = [reference_time, amplitude, rise_time, Tmin, Tmax, k_sig, *baselines.values(), 1.0]
+    actual = feature(t, flux, sigma=flux_err, band=band)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.1)
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="iminuit requires Python >= 3.8")
+def test_noisy_with_rise_only_notemp():
+    rng = np.random.default_rng(0)
+
+    band_wave_aa = {"g": 4770.0, "r": 6231.0, "i": 7625.0, "z": 9134.0}
+    average_nu = np.mean([3e10 / (w * 1e-8) for w in band_wave_aa.values()])
+
+    reference_time = 60000.0
+    amplitude = 1.0
+    rise_time = 10.0
+    Tmin = 10e3
+    k_sig = 4.0
+    baselines = {b: rng.exponential(scale=3 * amplitude / average_nu) for b in band_wave_aa}
+
+    t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * rise_time, 1000))
+    band = rng.choice(list(band_wave_aa), size=len(t))
+    waves = np.array([band_wave_aa[b] for b in band])
+
+    temp = Tmin
+    lum = amplitude / (np.exp(-(t - reference_time) / rise_time) + 1)
+
+    flux = np.pi * bb_nu(waves, temp) / (5.67e-5 * temp**4) * lum + np.array([baselines[b] for b in band])
+    # S/N = 5 for minimum flux, scale for Poisson noise
+    # We make noise a bit smaller because the optimization is not perfect
+    flux_err = 0.1 * np.sqrt(flux * np.min(flux) / 5.0)
+    flux += rng.normal(0.0, flux_err)
+
+    feature = RainbowSymmetricFit.from_angstrom(band_wave_aa, with_baseline=True, with_rise_only=True, with_temperature_evolution=False)
+
+    expected = [reference_time, amplitude, rise_time, Tmin, *baselines.values(), 1.0]
+    actual = feature(t, flux, sigma=flux_err, band=band)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.1)


### PR DESCRIPTION
This PR adds new sub-class for Rainbow, `RainbowSymmetricFit` that implements symmetric form of Bazin function for bolometric term, and slightly modified sigmoid function for temperature term, allowing for both rising and falling temperatures: 
```
bol = A / (exp(-dt/rise_time) + exp(dt/fall_time)) 
temp = T_min + (T_max - T_min) / (1 + exp(dt / k_sig)
```
These are better suited for constrained minimization, as they do not require complex constraints combining several parameters as in current implementation (not actually implemented there, leading to nonsensical results sometimes).

New class also has options for fitting fixed temperature models, as well as rising only bolometric function (effectively just a sigmoid). Both may be toggled independently.
In principle, this implementation supersedes both `basin.py` and `rising.py`, and may replace them completely.

PR also modifies the base class by exposing some internals from Minuit - new field `valid` reflects whether the minimization succeeded or not, and new field `minuit` allows directly accessing Minuit instance, e.g. to see its diagnostic output. 
I took a liberty of also increasing the verbosity level of Minuit itself (`print_level=1`) so that it prints some warnings during the minimization when it is problematic. Also, number of iterations is increased (`ncall=10000`, `iterate=10`), and default minimization strategy is changed to slightly more stable, but probably slower one (`strategy=2`). 
It should be, of course, made optional, but I found no easy way to pass them as additional keyword parameters for the `_eval` method (too many levels of abstraction above it). 

Related to the last point - as there is no easy way to add extra keywords to `_eval` method, I had to implement additional entry point for fitting with also getting back the parameter errors (instead of just making it an option). The method is `fit_and_get_errors`, with identical signature to `__call__`, and it returns the list containing arrays of parameters and their errors.

In general, the minimization on real data is not very stable, and strongly depends on initial parameters (as it is local minimizer only). I adjusted the heuristics for initial parameters to be slightly better, but it would be desirable to be able to also directly pass them during the feature evaluation. It comes down, again, to passing extra parameters to `__call__` (as well as to proper normalization of the values there, but that's easily doable).

Tests are not (yet) implemented for new class, as it will probably require some changes anyway.