### PR TITLE
Tests: change parameters for a rainbow model

### DIFF
--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -67,7 +67,7 @@ def test_noisy_all_functions_combination():
         -20,  # rise_time
     ]
 
-    doublexp_parameters = [60000.0, 1, 3, 5, 0.1]  # reference_time  # amplitude  # time1  # time2  # p
+    doublexp_parameters = [60000.0, 10, 5, 10, 0.1]  # reference_time  # amplitude  # time1  # time2  # p
 
     bolometric_names = ["bazin", "sigmoid", "linexp", "doublexp"]
     bolometric_params = [bazin_parameters, sigmoid_parameters, linexp_parameters, doublexp_parameters]


### PR DESCRIPTION
This should fix Intel Mac test failure