### PR TITLE
CI: Roll-back coverage python to 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - name: Install build deps
         run: pip install "${{ needs.py_build_deps.outputs.output }}"
       - name: Install system dependencies


### PR DESCRIPTION
There is probably some issue with numpy<2 and python 3.13?