### PR TITLE
Improved initial guesses/limits of Rainbow functions

### DIFF
--- a/light-curve/README.md
+++ b/light-curve/README.md
@@ -31,7 +31,7 @@ versions.
 
 | Arch \ OS   | Linux glibc 2.17+ | Linux musl 1.1+                | macOS                 | Windows https://github.com/light-curve/light-curve-python/issues/186 |
 |-------------|-------------------|--------------------------------|-----------------------|----------------------------------------------------------------------|
-| **x86-64**  | PyPI (MKL), conda | PyPI (MKL), conda              | PyPI macOS 13+, conda | PyPI, conda (both no Ceres, no GSL)                                  |
+| **x86-64**  | PyPI (MKL), conda | PyPI (MKL)                     | PyPI macOS 13+, conda | PyPI, conda (both no Ceres, no GSL)                                  |
 | **i686**    | src               | src                            | —                     | not tested                                                           |
 | **aarch64** | wheel             | wheel                          | PyPI macOS 14+, conda | not tested                                                           |
 | **ppc64le** | src               | not tested (no Rust toolchain) | —                     | —                                                                    |

--- a/light-curve/light_curve/light_curve_py/features/rainbow/bolometric.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/bolometric.py
@@ -102,12 +102,12 @@ class SigmoidBolometricTerm(BaseBolometricTerm):
         t_amplitude = np.ptp(t)
         m_amplitude = np.ptp(m)
 
-        mean_dt = np.median(t[1:] - t[:-1])
+        _, dt = t0_and_weighted_centroid_sigma(t, m, sigma)
 
         limits = {}
         limits["reference_time"] = (np.min(t) - 10 * t_amplitude, np.max(t) + 10 * t_amplitude)
         limits["amplitude"] = (0.0, 20 * m_amplitude)
-        limits["rise_time"] = (0.1 * mean_dt, 10 * t_amplitude)
+        limits["rise_time"] = (dt/100, 10 * t_amplitude)
 
         return limits
 
@@ -147,24 +147,13 @@ class BazinBolometricTerm(BaseBolometricTerm):
 
     @staticmethod
     def initial_guesses(t, m, sigma, band):
-        A = np.ptp(m)
+        A = 1.5 * max(np.max(m), np.ptp(m))
 
-        mc = m - np.min(m)  # To avoid crashing on all-negative data
-
-        # Naive peak position from the highest point
-        t0 = t[np.argmax(m)]
-        # Peak position as weighted centroid of everything above median
-        idx = m > np.median(m)
-        # t0 = np.sum(t[idx] * m[idx] / sigma[idx]) / np.sum(m[idx] / sigma[idx])
-        # Weighted centroid sigma
-        dt = np.sqrt(np.sum((t[idx] - t0) ** 2 * (mc[idx]) / sigma[idx]) / np.sum(mc[idx] / sigma[idx]))
+        t0, dt = t0_and_weighted_centroid_sigma(t, m, sigma)
 
         # Empirical conversion of sigma to rise/fall times
-        rise_time = dt / 2
-        fall_time = dt / 2
-
-        # Compensate for the difference between reference_time and peak position
-        t0 -= np.log(fall_time / rise_time) * rise_time * fall_time / (rise_time + fall_time)
+        rise_time = dt
+        fall_time = dt
 
         initial = {}
         initial["reference_time"] = t0
@@ -178,14 +167,14 @@ class BazinBolometricTerm(BaseBolometricTerm):
     def limits(t, m, sigma, band):
         t_amplitude = np.ptp(t)
         m_amplitude = np.ptp(m)
+        _, dt = t0_and_weighted_centroid_sigma(t, m, sigma)
 
-        mean_dt = np.median(t[1:] - t[:-1])
 
         limits = {}
         limits["reference_time"] = (np.min(t) - 10 * t_amplitude, np.max(t) + 10 * t_amplitude)
         limits["amplitude"] = (0.0, 20 * m_amplitude)
-        limits["rise_time"] = (0.1 * mean_dt, 10 * t_amplitude)
-        limits["fall_time"] = (0.1 * mean_dt, 10 * t_amplitude)
+        limits["rise_time"] = (dt/100, 10 * t_amplitude)
+        limits["fall_time"] = (dt/100, 10 * t_amplitude)
 
         return limits
 
@@ -198,7 +187,7 @@ class BazinBolometricTerm(BaseBolometricTerm):
 class LinexpBolometricTerm(BaseBolometricTerm):
     """Linexp function, symmetric form. Generated using a prototype version of Multi-view
     Symbolic Regression (Russeil et al. 2024, https://arxiv.org/abs/2402.04298) on
-    a SLSN ZTF light curve (https://ztf.snad.space/dr17/view/821207100004043)"""
+    a SLSN ZTF light curve (https://ztf.snad.space/dr17/view/821207100004043). Careful not very stable guesses/limits"""
 
     @staticmethod
     def parameter_names():
@@ -226,6 +215,7 @@ class LinexpBolometricTerm(BaseBolometricTerm):
     def initial_guesses(t, m, sigma, band):
         A = np.ptp(m)
         med_dt = median_dt(t, band)
+        t0, dt = t0_and_weighted_centroid_sigma(t, m, sigma)
 
         # Compute points after or before maximum
         peak_time = t[np.argmax(m)]
@@ -276,7 +266,6 @@ class DoublexpBolometricTerm(BaseBolometricTerm):
     @staticmethod
     def value(t, t0, amplitude, time1, time2, p):
         dt = t - t0
-
         result = np.zeros_like(dt)
 
         # To avoid numerical overflows
@@ -290,22 +279,19 @@ class DoublexpBolometricTerm(BaseBolometricTerm):
 
     @staticmethod
     def initial_guesses(t, m, sigma, band):
-        A = np.ptp(m)
-        med_dt = median_dt(t, band)
+        A = max(np.max(m), np.ptp(m))
+        t0, dt = t0_and_weighted_centroid_sigma(t, m, sigma)
 
-        # Naive peak position from the highest point
-        t0 = t[np.argmax(m)]
-
-        # Empirical conversion of sigma to rise/fall times
-        time1 = 50 * med_dt
-        time2 = 50 * med_dt
+        # Empirical conversion of sigma to times
+        time1 = 2 * dt
+        time2 = 2 * dt
 
         initial = {}
         initial["reference_time"] = t0
         initial["amplitude"] = A
         initial["time1"] = time1
         initial["time2"] = time2
-        initial["p"] = 0.1
+        initial["p"] = 1
 
         return initial
 
@@ -313,14 +299,14 @@ class DoublexpBolometricTerm(BaseBolometricTerm):
     def limits(t, m, sigma, band):
         t_amplitude = np.ptp(t)
         m_amplitude = np.ptp(m)
-        med_dt = median_dt(t, band)
+        _, dt = t0_and_weighted_centroid_sigma(t, m, sigma)
 
         limits = {}
         limits["reference_time"] = (np.min(t) - 10 * t_amplitude, np.max(t) + 10 * t_amplitude)
         limits["amplitude"] = (0.0, 10 * m_amplitude)
-        limits["time1"] = (med_dt, 2 * t_amplitude)
-        limits["time2"] = (med_dt, 2 * t_amplitude)
-        limits["p"] = (1e-4, 10)
+        limits["time1"] = (dt/10, 2 * t_amplitude)
+        limits["time2"] = (dt/10, 2 * t_amplitude)
+        limits["p"] = (1e-2, 100)
 
         return limits
 
@@ -336,12 +322,24 @@ class DoublexpBolometricTerm(BaseBolometricTerm):
 
 def median_dt(t, band):
     # Compute the median distance between points in each band
+    # Caution when using this method as it might be strongly biaised because of ZTF high cadence a given day.
     dt = []
     for b in np.unique(band):
         dt += list(t[band == b][1:] - t[band == b][:-1])
     med_dt = np.median(dt)
     return med_dt
 
+def t0_and_weighted_centroid_sigma(t, m, sigma):
+        # To avoid crashing on all-negative data
+        mc = m - np.min(m)
+
+        # Peak position as weighted centroid of everything above median
+        idx = m > np.median(m)
+        t0 = np.sum(t[idx] * m[idx] / sigma[idx]) / np.sum(m[idx] / sigma[idx])
+
+        # Weighted centroid sigma
+        dt = np.sqrt(np.sum((t[idx] - t0) ** 2 * (mc[idx]) / sigma[idx]) / np.sum(mc[idx] / sigma[idx]))
+        return t0, dt
 
 bolometric_terms = {
     "sigmoid": SigmoidBolometricTerm,

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -116,9 +116,9 @@ def test_noisy_all_functions_combination():
             # The first test might be too rigid. The second test allow for good local minima to be accepted
             np.testing.assert_allclose(actual[:-1], expected[:-1], rtol=0.1)
 
-            # If either the absolute or the relative test passes, it is accepted. 
-	    # It prevents linexp, which include a flat exactly 0 baseline to not pass the test because
-	    # of very minor parameter differences that lead to a major relative difference.
+            # If either the absolute or the relative test passes, it is accepted.
+            # It prevents linexp, which include a flat exactly 0 baseline to not pass the test because
+            # of very minor parameter differences that lead to a major relative difference.
             np.testing.assert_allclose(
                 feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1, atol=0.1, strict=False
             )

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -15,10 +15,10 @@ def test_noisy_with_baseline():
     fall_time = 30.0
     Tmin = 5e3
     Tmax = 15e3
-    k_sig = 4.0
+    t_color = 10
     baselines = {b: 0.3 * amplitude + rng.exponential(scale=0.3 * amplitude) for b in band_wave_aa}
 
-    expected = [reference_time, amplitude, rise_time, fall_time, Tmin, Tmax, k_sig, *baselines.values(), 1.0]
+    expected = [reference_time, amplitude, rise_time, fall_time, Tmin, Tmax, t_color, *baselines.values(), 1.0]
 
     feature = RainbowFit.from_angstrom(band_wave_aa, with_baseline=True, temperature="sigmoid", bolometric="bazin")
 
@@ -32,15 +32,15 @@ def test_noisy_with_baseline():
 
     actual = feature(t, flux, sigma=flux_err, band=band)
 
-    # import matplotlib.pyplot as plt
-    # plt.scatter(t, flux, s=5, label="data")
-    # plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
-    # plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
-    # plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
-    # plt.legend()
-    # plt.show()
+    #import matplotlib.pyplot as plt
+    #plt.scatter(t, flux, s=5, label="data")
+    #plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
+    #plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
+    #plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
+    #plt.legend()
+    #plt.show()
 
-    np.testing.assert_allclose(actual[:-1], expected[:-1], rtol=0.1)
+    np.testing.assert_allclose(feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1)
 
 
 def test_noisy_all_functions_combination():
@@ -103,17 +103,21 @@ def test_noisy_all_functions_combination():
 
             actual = feature(t, flux, sigma=flux_err, band=band)
 
-            # import matplotlib.pyplot as plt
-            # plt.figure()
-            # plt.scatter(t, flux, s=5, label="data")
-            # plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
-            # plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
-            # plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
-            # plt.ylim(-.05, flux.max()+0.1)
-            # plt.legend()
-            # plt.show()
+            #import matplotlib.pyplot as plt
+            #plt.figure()
+            #plt.scatter(t, flux, s=5, label="data")
+            #plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
+            #plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
+            #plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
+            #plt.ylim(-.05, flux.max()+0.1)
+            #plt.legend()
+            #plt.show()
 
+            #The first test might be too rigid. The second test allow for good local minima to be accepted
             np.testing.assert_allclose(actual[:-1], expected[:-1], rtol=0.1)
+            
+            # If either the absolute or the relative test passes, it is accepted. It prevents linexp, which include a flat exactly 0 baseline to not pass the test because of very minor parameter differences that lead to a major relative difference.
+            np.testing.assert_allclose(feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1, atol=0.1, strict=False)
 
 
 def test_scaler_from_flux_list_input():

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -116,7 +116,9 @@ def test_noisy_all_functions_combination():
             # The first test might be too rigid. The second test allow for good local minima to be accepted
             np.testing.assert_allclose(actual[:-1], expected[:-1], rtol=0.1)
 
-            # If either the absolute or the relative test passes, it is accepted. It prevents linexp, which include a flat exactly 0 baseline to not pass the test because of very minor parameter differences that lead to a major relative difference.
+            # If either the absolute or the relative test passes, it is accepted. 
+	    # It prevents linexp, which include a flat exactly 0 baseline to not pass the test because
+	    # of very minor parameter differences that lead to a major relative difference.
             np.testing.assert_allclose(
                 feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1, atol=0.1, strict=False
             )

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -32,13 +32,13 @@ def test_noisy_with_baseline():
 
     actual = feature(t, flux, sigma=flux_err, band=band)
 
-    #import matplotlib.pyplot as plt
-    #plt.scatter(t, flux, s=5, label="data")
-    #plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
-    #plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
-    #plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
-    #plt.legend()
-    #plt.show()
+    # import matplotlib.pyplot as plt
+    # plt.scatter(t, flux, s=5, label="data")
+    # plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
+    # plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
+    # plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
+    # plt.legend()
+    # plt.show()
 
     np.testing.assert_allclose(feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1)
 
@@ -103,21 +103,23 @@ def test_noisy_all_functions_combination():
 
             actual = feature(t, flux, sigma=flux_err, band=band)
 
-            #import matplotlib.pyplot as plt
-            #plt.figure()
-            #plt.scatter(t, flux, s=5, label="data")
-            #plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
-            #plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
-            #plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
-            #plt.ylim(-.05, flux.max()+0.1)
-            #plt.legend()
-            #plt.show()
+            # import matplotlib.pyplot as plt
+            # plt.figure()
+            # plt.scatter(t, flux, s=5, label="data")
+            # plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
+            # plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
+            # plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
+            # plt.ylim(-.05, flux.max()+0.1)
+            # plt.legend()
+            # plt.show()
 
-            #The first test might be too rigid. The second test allow for good local minima to be accepted
+            # The first test might be too rigid. The second test allow for good local minima to be accepted
             np.testing.assert_allclose(actual[:-1], expected[:-1], rtol=0.1)
-            
+
             # If either the absolute or the relative test passes, it is accepted. It prevents linexp, which include a flat exactly 0 baseline to not pass the test because of very minor parameter differences that lead to a major relative difference.
-            np.testing.assert_allclose(feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1, atol=0.1, strict=False)
+            np.testing.assert_allclose(
+                feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1, atol=0.1, strict=False
+            )
 
 
 def test_scaler_from_flux_list_input():


### PR DESCRIPTION
General improvement of parameters limits and initial guesses for the Rainbow functions:

-  Most absolute values have been replaced by scaling values (except for the linexp function that should be fixed in the future) . 
-  limits/initial guesses have been improved and are generally better fitted for transient data.
- Values scaling on med_dt (median tine diff between two consecutive points) have been changed to a scaling on dt (weighted_centroid_sigma). Although less intuitive, med_dt has proven to be unreliable in some cases because of the very high cadence of ZTF on certain days. This would lead to very fast med_dt (< 1 day) that would often destroy the fit. The weighted_centroid_sigma appears way more stable.