### PR TITLE
Free-threading Python support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_minor: [ '9', '10', '11', '12', '13' ]
+        python_minor: [ '9', '10', '11', '12', '13', '13t' ]
         os: [ ubuntu-latest ]
         # Just a single ARM worker to be sure that it works
         include:
@@ -193,22 +193,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13t
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
+          python-version: '3.13t'
       - name: Get minimum supported Rust version
         run: echo "::set-output name=msrv::$(grep '^rust-version = ' Cargo.toml | grep -o '[0-9.]\+')"
         id: get_msrv
@@ -228,4 +216,5 @@ jobs:
       - name: Build
         run: |
           rustup default ${{ steps.get_msrv.outputs.msrv }}
-          maturin build --find-interpreter
+          maturin build -i python3.9
+          maturin build -i python3.13t

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
---
+- Bump both `PyO3` and `rust-numpy` to v0.24 https://github.com/light-curve/light-curve-python/pull/499
 
 ### Deprecated
 
@@ -41,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Experimental Feature Breaking**: change parameter limits for Rainbow https://github.com/light-curve/light-curve-python/pull/494
+- **Experimental Feature Breaking**: change parameter limits for
+  Rainbow https://github.com/light-curve/light-curve-python/pull/494
 
 ### Removed
 
@@ -50,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Rainbow multi-band scaler didn't work with list inputs https://github.com/light-curve/light-curve-python/issues/492 https://github.com/light-curve/light-curve-python/pull/493
+- Rainbow multi-band scaler didn't work with list
+  inputs https://github.com/light-curve/light-curve-python/issues/492 https://github.com/light-curve/light-curve-python/pull/493
 
 ## [0.10.0] 2025-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
---
+- Mark the module as no-GIL, which enables free-threading Python (can be built from source, not provided so far) https://github.com/light-curve/light-curve-python/pull/499
 
 ### Changed
 

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
+checksum = "a7cfbf3f0feededcaa4d289fe3079b03659e85c5b5a177f4ba6fb01ab4fb3e39"
 dependencies = [
  "libc",
  "ndarray 0.16.1",
@@ -1444,6 +1444,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
+ "pyo3-build-config",
  "rustc-hash",
 ]
 
@@ -1616,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "7f1c6c3591120564d64db2261bec5f910ae454f01def849b9c22835a84695e86"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1635,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1645,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "5507651906a46432cdda02cd02dd0319f6064f1374c9147c45b978621d2c3a9c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1655,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "b0d394b5b4fd8d97d48336bb0dd2aebabad39f1d294edd6bcd2cccf2eefe6f42"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1667,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "fd72da09cfa943b1080f621f024d2ef7e2773df7badd51aa30a2be1f8caa7c8e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2196,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "termcolor"

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -44,11 +44,11 @@ mimalloc = { version = "0.1.42", features = [
     "local_dynamic_tls",
 ], optional = true }
 ndarray = { version = "0.16.1", features = ["rayon"] }
-numpy = "0.23.0"
+numpy = "0.24.0"
 num_cpus = "1.13.0"
 num-traits = "0.2"
 once_cell = "1"
-pyo3 = { version = "0.23.5", features = [
+pyo3 = { version = "0.24.0", features = [
     "extension-module",
     "multiple-pymethods",
 ] }

--- a/light-curve/README.md
+++ b/light-curve/README.md
@@ -53,6 +53,9 @@ We stopped publishing all PyPy wheels (https://github.com/light-curve/light-curv
 and the PPC64le CPython glibc wheel (https://github.com/light-curve/light-curve-python/issues/479),
 please feel free to open an issue if you need any of them.
 
+[Free-threading Python](https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython) is supported when built from source.
+No pre-built distributions are provided so far, please comment on these issues if you need them: [PyPI binary wheel issue](https://github.com/light-curve/light-curve-python/issues/500), [conda-forge package issue](https://github.com/conda-forge/light-curve-python-feedstock/issues/11).
+
 See [bellow](#build-from-source) for the details on how to build the package from the source code.
 
 ## Feature evaluators

--- a/light-curve/pyproject.toml
+++ b/light-curve/pyproject.toml
@@ -62,6 +62,19 @@ dev = [
     "black",
     "ruff",
 ]
+# cesium and iminuit don't support free-threading yet
+dev-free-threading = [
+    "pytest",
+    "markdown-pytest",
+    "pytest-benchmark",
+    "pytest-subtests>=0.10",
+    "numpy",
+    "scipy",
+    "joblib",
+    "pandas",
+    "black",
+    "ruff",
+]
 
 [tool.maturin]
 # It asks to use Cargo.lock to make the build reproducible
@@ -148,10 +161,10 @@ markers = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{39,310,311,312,313}-{base,test}
+envlist = py{39,310,311,312,313,313t}-{base,test}
 isolated_build = True
 
-[testenv:py{39,310,311,312,313}-base]
+[testenv:py{39,310,311,312,313,313t}-base]
 change_dir = {envtmpdir}
 extras =
 commands =
@@ -163,6 +176,17 @@ set_env =
 extras = dev
 commands =
     pytest README.md tests/ light_curve/
+    ruff check .
+set_env =
+    CARGO_TARGET_DIR = {tox_root}/target
+
+[testenv:py313t-test]
+extras = dev-free-threading
+commands =
+    pytest README.md tests/ light_curve/ \
+        --ignore tests/test_w_bench.py \
+        --ignore=tests/light_curve_py/features/test_rainbow.py \
+        --deselect=README.md::test_rainbow_fit_example
     ruff check .
 set_env =
     CARGO_TARGET_DIR = {tox_root}/target

--- a/light-curve/src/lib.rs
+++ b/light-curve/src/lib.rs
@@ -26,7 +26,7 @@ static GLOBAL_ALLOCATOR: MiMalloc = MiMalloc;
 ///
 /// dm-lg(dt) maps generator is represented by `DmDt` class, while all other classes are
 /// feature extractors
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn light_curve(py: Python, m: Bound<PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
 


### PR DESCRIPTION
Updates pyo3 and rust-numpy to v0.24, which brings free-threading python support.