### PR TITLE
Cast inputs to a common dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Mark the module as no-GIL, which enables free-threaded Python (can be built from source, not provided so far via
   PyPI/conda) https://github.com/light-curve/light-curve-python/pull/499
+- Allow non-numpy inputs and casting mismatched f32 arrays to f64 for the feature extractions with newly added
+  `cast: bool = False` argument. We plan to change the default value to `True` in a future 0.x version.
+  https://github.com/light-curve/light-curve-python/issues/509 https://github.com/light-curve/light-curve-python/pull/512
 
 ### Changed
 

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "serde-pickle",
  "serde_json",
  "thiserror 2.0.12",
+ "unarray",
  "unzip3",
 ]
 
@@ -2365,6 +2366,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -59,6 +59,7 @@ serde = { version = "1", features = ["derive"] }
 serde-pickle = "1"
 serde_json = "1"
 thiserror = "2"
+unarray = "0.1.4"
 unzip3 = "1.0.0"
 
 [dependencies.light-curve-dmdt]

--- a/light-curve/src/dmdt.rs
+++ b/light-curve/src/dmdt.rs
@@ -1142,21 +1142,27 @@ impl DmDt {
     ///     Time moments, must be sorted
     /// sorted : bool or None, optional
     ///     `True` guarantees that `t` is sorted
+    /// cast : bool
+    ///     If `False` allow np.ndarray input only, `True` allows casting.
+    ///     Casting provides more flexibility with input types at the cost of
+    //      performance.
     ///
     /// Returns
     /// 1d-array of float
     ///
-    #[pyo3(signature=(t, *, sorted=None))]
+    #[pyo3(signature=(t, *, sorted=None, cast=false))]
     fn count_dt<'py>(
         &self,
         py: Python<'py>,
         t: Bound<'py, PyAny>,
         sorted: Option<bool>,
+        cast: bool,
     ) -> Res<Bound<'py, PyUntypedArray>> {
         dtype_dispatch!(
             |t| self.dmdt_f32.py_count_dt(py, t, sorted),
             |t| self.dmdt_f64.py_count_dt(py, t, sorted),
-            t
+            t;
+            cast=cast
         )
     }
 
@@ -1203,24 +1209,30 @@ impl DmDt {
     ///     Magnitudes
     /// sorted : bool or None, optional
     ///     `True` guarantees that the light curve is sorted
+    /// cast : bool
+    ///     If `False` allow np.ndarray input only, `True` allows casting.
+    ///     Casting provides more flexibility with input types at the cost of
+    //      performance.
     ///
     /// Returns
     /// -------
     /// 2d-ndarray of float
     ///
-    #[pyo3(signature = (t, m, *, sorted=None))]
+    #[pyo3(signature = (t, m, *, sorted=None, cast=false))]
     fn points<'py>(
         &self,
         py: Python<'py>,
         t: Bound<'py, PyAny>,
         m: Bound<'py, PyAny>,
         sorted: Option<bool>,
+        cast: bool,
     ) -> Res<Bound<'py, PyUntypedArray>> {
         dtype_dispatch!(
             |t, m| self.dmdt_f32.py_points(py, t, m, sorted),
             |t, m| self.dmdt_f64.py_points(py, t, m, sorted),
             t,
-            =m
+            =m;
+            cast=cast
         )
     }
 
@@ -1372,12 +1384,15 @@ impl DmDt {
     ///     Uncertainties
     /// sorted : bool or None, optional
     ///     `True` guarantees that the light curve is sorted
-    ///
+    /// cast : bool
+    ///     If `False` allow np.ndarray input only, `True` allows casting.
+    ///     Casting provides more flexibility with input types at the cost of
+    //      performance.
     /// Returns
     /// -------
     /// 2d-array of float
     ///
-    #[pyo3(signature = (t, m, sigma, *, sorted=None))]
+    #[pyo3(signature = (t, m, sigma, *, sorted=None, cast=false))]
     fn gausses<'py>(
         &self,
         py: Python<'py>,
@@ -1385,13 +1400,15 @@ impl DmDt {
         m: Bound<'py, PyAny>,
         sigma: Bound<'py, PyAny>,
         sorted: Option<bool>,
+        cast: bool,
     ) -> Res<Bound<'py, PyUntypedArray>> {
         dtype_dispatch!(
             |t, m, sigma| self.dmdt_f32.py_gausses(py, t, m, sigma, sorted),
             |t, m, sigma| self.dmdt_f64.py_gausses(py, t, m, sigma, sorted),
             t,
             =m,
-            =sigma
+            =sigma;
+            cast=cast
         )
     }
 

--- a/light-curve/src/features.rs
+++ b/light-curve/src/features.rs
@@ -73,6 +73,8 @@ const METHOD_CALL_DOC: &str = r#"__call__(self, t, m, sigma=None, *, fill_value=
     cast : bool, optional
         Allows non-numpy input and casting of arrays to a common dtype.
         If `False`, inputs must be `np.ndarray` instances with matched dtypes.
+        Casting provides more flexibility with input types at the cost of
+        performance.
     Returns
     -------
     ndarray of np.float32 or np.float64

--- a/light-curve/src/np_array.rs
+++ b/light-curve/src/np_array.rs
@@ -1,7 +1,11 @@
 use crate::errors::{Exception, Res};
 
+use itertools::{izip, Either};
 use numpy::prelude::*;
-use numpy::{Element, PyArray1, PyReadonlyArray1, PyUntypedArray, PyUntypedArrayMethods};
+use numpy::{
+    AllowTypeChange, PyArray1, PyArrayLike1, PyReadonlyArray1, PyUntypedArray,
+    PyUntypedArrayMethods,
+};
 use pyo3::prelude::*;
 
 pub(crate) type Arr<'a, T> = PyReadonlyArray1<'a, T>;
@@ -22,7 +26,7 @@ impl DType for f64 {
     }
 }
 
-pub(crate) fn unknown_type_exception(name: &str, obj: Bound<PyAny>) -> Exception {
+pub(crate) fn unknown_type_exception(name: &str, obj: &Bound<PyAny>) -> Exception {
     let message = if let Ok(arr) = obj.downcast::<PyUntypedArray>() {
         let ndim = arr.ndim();
         if ndim != 1 {
@@ -46,59 +50,165 @@ pub(crate) fn unknown_type_exception(name: &str, obj: Bound<PyAny>) -> Exception
     Exception::TypeError(message)
 }
 
-pub(crate) fn extract_matched_array<'py, T>(
-    y_name: &'static str,
-    y: Bound<'py, PyAny>,
-    x_name: &'static str,
-    x: &Arr<'py, T>,
-    check_size: bool,
-) -> Res<Arr<'py, T>>
-where
-    T: Element + DType + 'py,
-{
-    if let Ok(y) = y.downcast::<PyArray1<T>>() {
-        let y = y.readonly();
-        if check_size {
-            if y.len() == x.len() {
-                Ok(y)
-            } else {
-                Err(Exception::ValueError(format!(
-                    "Mismatched lengths: '{}': {}, '{}': {}",
-                    x_name,
-                    x.len(),
-                    y_name,
-                    y.len(),
-                )))
-            }
+fn cast_fail_reason(
+    idx: usize,
+    names: &'static [&'static str],
+    objects: &[&Bound<PyAny>],
+    good_f32_arrays: &[PyReadonlyArray1<f32>],
+    good_f64_arrays: &[PyReadonlyArray1<f64>],
+) -> Exception {
+    let first_name = names.first().expect("Empty names slice");
+    let fist_obj = objects.first().expect("Empty objects slice");
+
+    // If the very first argument downcast
+    if idx == 0 {
+        return unknown_type_exception(first_name, fist_obj);
+    }
+
+    let (first_arr, first_dtype_name) = if good_f32_arrays.is_empty() {
+        (
+            good_f64_arrays
+                .first()
+                .expect("Empty good_f64_arrays slice")
+                .as_untyped(),
+            f64::dtype_name(),
+        )
+    } else {
+        (
+            good_f32_arrays
+                .first()
+                .expect("Empty good_f32_arrays slice")
+                .as_untyped(),
+            f32::dtype_name(),
+        )
+    };
+
+    let fail_name = names.get(idx).expect("idx is out of bounds of names slice");
+    let fail_obj = objects
+        .get(idx)
+        .expect("idx is out of bounds of names slice");
+
+    let error_message = if let Ok(fail_arr) = fail_obj.downcast::<PyUntypedArray>() {
+        if fail_arr.ndim() != 1 {
+            format!(
+                "'{}' is a {}-d array, only 1-d arrays are supported.",
+                fail_name,
+                fail_arr.ndim()
+            )
         } else {
-            Ok(y)
+            let first_arr_dtype_str = match first_arr.dtype().str() {
+                Ok(s) => s,
+                Err(err) => return err.into(),
+            };
+            let fail_arr_dtype_str = match fail_arr.dtype().str() {
+                Ok(s) => s,
+                Err(err) => return err.into(),
+            };
+            format!(
+                "Mismatched dtypes: '{first_name}': {first_arr_dtype_str}, '{fail_name}': {fail_arr_dtype_str}",
+            )
         }
     } else {
-        let error_message = if let Ok(y_arr) = y.downcast::<PyUntypedArray>() {
-            if y_arr.ndim() != 1 {
-                format!(
-                    "'{}' is a {}-d array, only 1-d arrays are supported.",
-                    y_name,
-                    y_arr.ndim()
-                )
-            } else {
-                format!(
-                    "Mismatched dtypes: '{}': {}, '{}': {}",
-                    x_name,
-                    x.dtype().str()?,
-                    y_name,
-                    y_arr.dtype().str()?
-                )
-            }
-        } else {
-            format!(
-                "'{y_name}' must be a numpy array of the same shape and dtype as '{x_name}', '{x_name}' has type 'np.ndarray[{x_dtype}]', '{y_name}' has type '{y_type}')",
-                y_type = y.get_type().name()?,
-                x_dtype = T::dtype_name()
-            )
+        let fail_obj_type_name = match fail_obj.get_type().name() {
+            Ok(s) => s,
+            Err(err) => return err.into(),
         };
-        Err(Exception::TypeError(error_message))
+        format!(
+            "'{fail_name}' must be a numpy array of the same shape and dtype as '{first_name}', '{first_name}' has type 'np.ndarray[{first_dtype_name}]', '{fail_name}' has type '{fail_obj_type_name}')",
+        )
+    };
+    Exception::TypeError(error_message)
+}
+
+pub(crate) enum GenericVecOfArrays<'py> {
+    F32(Vec<PyReadonlyArray1<'py, f32>>),
+    F64(Vec<PyReadonlyArray1<'py, f64>>),
+}
+
+impl<'py> GenericVecOfArrays<'py> {
+    fn first_len(&self) -> Option<usize> {
+        match self {
+            Self::F32(v) => v.first().map(|arr| arr.len()),
+            Self::F64(v) => v.first().map(|arr| arr.len()),
+        }
     }
+
+    fn iter_len(&'py self) -> impl Iterator<Item = usize> + 'py {
+        match self {
+            Self::F32(v) => Either::Left(v.iter().map(|arr| arr.len())),
+            Self::F64(v) => Either::Right(v.iter().map(|arr| arr.len())),
+        }
+    }
+}
+
+fn try_downcast_objects_to_f32_arrays<'py>(
+    objects: &[&Bound<'py, PyAny>],
+) -> Vec<PyReadonlyArray1<'py, f32>> {
+    objects
+        .iter()
+        .map(|&obj| obj.downcast::<PyArray1<f32>>())
+        .take_while(|result| result.is_ok())
+        // It is safe to unwrap, because we have just checked that it is Ok
+        .map(|result| result.unwrap().readonly())
+        .collect()
+}
+
+fn try_downcast_to_f64_array<'py>(obj: &Bound<'py, PyAny>) -> Option<PyReadonlyArray1<'py, f64>> {
+    if let Ok(py_array) = obj.downcast::<PyArray1<f64>>() {
+        Some(py_array.readonly())
+    } else if let Ok(as_array) = PyArrayLike1::<f64, AllowTypeChange>::extract_bound(obj) {
+        Some(as_array.readonly())
+    } else {
+        None
+    }
+}
+
+fn downcast_objects<'py>(
+    names: &'static [&'static str],
+    objects: &[&Bound<'py, PyAny>],
+) -> Res<GenericVecOfArrays<'py>> {
+    let f32_arrays = try_downcast_objects_to_f32_arrays(objects);
+    if f32_arrays.len() == names.len() {
+        Ok(GenericVecOfArrays::F32(f32_arrays))
+    } else {
+        let mut result = Vec::with_capacity(names.len());
+        for f32_arr in f32_arrays.iter() {
+            let f64_arr = f32_arr.cast::<f64>(false)?;
+            result.push(f64_arr.readonly());
+        }
+        for (idx, &obj) in objects.iter().enumerate().skip(result.len()) {
+            let py_ro_array = try_downcast_to_f64_array(obj)
+                .ok_or_else(|| cast_fail_reason(idx, names, objects, &f32_arrays, &result))?;
+            result.push(py_ro_array);
+        }
+        Ok(GenericVecOfArrays::F64(result))
+    }
+}
+
+pub(crate) fn downcast_and_validate<'py>(
+    names: &'static [&'static str],
+    objects: &[&Bound<'py, PyAny>],
+    check_size: &[bool],
+) -> Res<GenericVecOfArrays<'py>> {
+    assert_eq!(names.len(), objects.len());
+
+    let arrays = downcast_objects(names, objects)?;
+    let first_array_len = match arrays.first_len() {
+        Some(len) => len,
+        None => return Ok(arrays),
+    };
+    // We checked that 1) names size matches objects size, 2) objects is not empty
+    let first_name = names[0];
+
+    for (&name, length, &check) in izip!(&names[1..], arrays.iter_len().skip(1), check_size) {
+        if check && length != first_array_len {
+            return Err(Exception::ValueError(format!(
+                "Mismatched lengths: '{}': {}, '{}': {}",
+                first_name, first_array_len, name, length,
+            )));
+        }
+    }
+    Ok(arrays)
 }
 
 macro_rules! _distinguish_eq_symbol {
@@ -111,34 +221,35 @@ macro_rules! _distinguish_eq_symbol {
 }
 
 macro_rules! dtype_dispatch {
-    ($func: tt ($first_arg:expr $(,$eq:tt $arg:expr)* $(,)?)) => {
+    // @call variants are for the internal usage only
+    (@call $func:expr, $arrays:ident, $_arg1:expr,) => {{
+        let func = $func;
+        func($arrays[0].clone())
+    }};
+    (@call $func:expr, $arrays:ident, $_arg1:expr, $_arg2:expr,) => {{
+        let func = $func;
+        func($arrays[0].clone(), $arrays[1].clone())
+    }};
+    (@call $func:expr, $arrays:ident, $_arg1:expr, $_arg2:expr, $_arg3:expr,) => {{
+        let func = $func;
+        func($arrays[0].clone(), $arrays[1].clone(), $arrays[2].clone())
+    }};
+    ($func:tt ($first_arg:expr $(,$eq:tt $arg:expr)* $(,)?)) => {
         dtype_dispatch!($func, $func, $first_arg $(,$eq $arg)*)
     };
-    ($f32:expr, $f64:expr, $first_arg:expr $(,)?) => {{
-        if let Ok(x32) = $first_arg.downcast::<numpy::PyArray1<f32>>() {
-            let x32 = x32.readonly();
-            let f32 = $f32;
-            f32(x32)
-        } else if let Ok(x64) = $first_arg.downcast::<numpy::PyArray1<f64>>() {
-            let x64 = x64.readonly();
-            let f64 = $f64;
-            f64(x64)
-        } else {
-            Err(crate::np_array::unknown_type_exception(stringify!($first_arg), $first_arg.clone()))
-        }
-    }};
-    ($f32:expr, $f64:expr, $first_arg:expr $(,$eq:tt $arg:expr)+ $(,)?) => {{
-        let x_name = stringify!($first_arg);
-        if let Ok(x32) = $first_arg.downcast::<numpy::PyArray1<f32>>() {
-            let x32 = x32.readonly();
-            let f32 = $f32;
-            f32(x32.clone(), $(crate::np_array::extract_matched_array(stringify!($arg), $arg, x_name, &x32, _distinguish_eq_symbol!($eq))?,)*)
-        } else if let Ok(x64) = $first_arg.downcast::<numpy::PyArray1<f64>>() {
-            let x64 = x64.readonly();
-            let f64 = $f64;
-            f64(x64.clone(), $(crate::np_array::extract_matched_array(stringify!($arg), $arg, x_name, &x64, _distinguish_eq_symbol!($eq))?,)*)
-        } else {
-            Err(crate::np_array::unknown_type_exception(stringify!($first_arg), $first_arg.clone()))
+    ($f32:expr, $f64:expr, $first_arg:expr $(,$eq:tt $arg:expr)* $(,)?) => {{
+        let names = &[stringify!($first_arg), $(stringify!($arg), )*];
+        let objects = &[&$first_arg, $(&$arg, )*];
+        let check_size = &[ $(_distinguish_eq_symbol!($eq), )* ];
+
+        let generic_arrays = crate::np_array::downcast_and_validate(names, objects, check_size)?;
+        match generic_arrays {
+            crate::np_array::GenericVecOfArrays::F32(arrays) => {
+                dtype_dispatch!(@call $f32, arrays, $first_arg, $($arg,)*)
+            }
+            crate::np_array::GenericVecOfArrays::F64(arrays) => {
+                dtype_dispatch!(@call $f64, arrays, $first_arg, $($arg,)*)
+            }
         }
     }};
 }

--- a/light-curve/src/np_array.rs
+++ b/light-curve/src/np_array.rs
@@ -293,7 +293,7 @@ macro_rules! dtype_dispatch {
     ($f32:expr, $f64:expr, $first_arg:expr $(,$eq:tt $arg:expr)* $(,)?) => {
         dtype_dispatch!($f32, $f64, $first_arg $(,$eq $arg)*; cast=false)
     };
-    ($f32:expr, $f64:expr, $first_arg:expr $(,$eq:tt $arg:expr)*; cast=$cast:expr $(,)?) => {{
+    ($f32:expr, $f64:expr, $first_arg:expr $(,$eq:tt $arg:expr)*; cast=$cast:expr) => {{
         let names = &[stringify!($first_arg), $(stringify!($arg), )*];
         let objects = &[&$first_arg, $(&$arg, )*];
         let check_size = &[ false, $(_distinguish_eq_symbol!($eq), )* ];

--- a/light-curve/src/np_array.rs
+++ b/light-curve/src/np_array.rs
@@ -288,7 +288,7 @@ macro_rules! dtype_dispatch {
     ($func:tt ($first_arg:expr $(,$eq:tt $arg:expr)* $(,)?)) => {
         dtype_dispatch!($func, $func, $first_arg $(,$eq $arg)*)
     };
-    ($func:tt ($first_arg:expr $(,$eq:tt $arg:expr)*, cast=$cast:expr $(,)?)) => {
+    ($func:tt ($first_arg:expr $(,$eq:tt $arg:expr)*; cast=$cast:expr $(,)?)) => {
         dtype_dispatch!($func, $func, $first_arg $(,$eq $arg)*; cast=$cast)
     };
     ($f32:expr, $f64:expr, $first_arg:expr $(,$eq:tt $arg:expr)* $(,)?) => {

--- a/light-curve/tests/light_curve_ext/test_dmdt.py
+++ b/light-curve/tests/light_curve_ext/test_dmdt.py
@@ -282,7 +282,14 @@ def test_dmdt_points_dtype(t_dtype, m_dtype):
     t = np.linspace(0, 1, 11, dtype=t_dtype)
     m = np.asarray(t, dtype=m_dtype)
     dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
-    values = dmdt.points(t, m)
+
+    if t_dtype is m_dtype:
+        context = nullcontext()
+    else:
+        context = pytest.raises(TypeError)
+    with context:
+        dmdt.points(t, m, cast=False)
+    values = dmdt.points(t, m, cast=True)
     assert values.dtype == np.result_type(t, m)
 
 
@@ -292,7 +299,14 @@ def test_dmdt_gausses_dtype(t_dtype, m_dtype, sigma_dtype):
     m = np.asarray(t, dtype=m_dtype)
     sigma = np.asarray(t, dtype=sigma_dtype)
     dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
-    values = dmdt.gausses(t, m, sigma)
+
+    if t_dtype is m_dtype is sigma_dtype:
+        context = nullcontext()
+    else:
+        context = pytest.raises(TypeError)
+    with context:
+        dmdt.gausses(t, m, sigma, cast=False)
+    values = dmdt.gausses(t, m, sigma, cast=True)
     assert values.dtype == np.result_type(t, m, sigma)
 
 

--- a/light-curve/tests/light_curve_ext/test_dmdt.py
+++ b/light-curve/tests/light_curve_ext/test_dmdt.py
@@ -282,12 +282,8 @@ def test_dmdt_points_dtype(t_dtype, m_dtype):
     t = np.linspace(0, 1, 11, dtype=t_dtype)
     m = np.asarray(t, dtype=m_dtype)
     dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
-    if t_dtype is m_dtype:
-        context = nullcontext()
-    else:
-        context = pytest.raises(TypeError)
-    with context:
-        dmdt.points(t, m)
+    values = dmdt.points(t, m)
+    assert values.dtype == np.result_type(t, m)
 
 
 @pytest.mark.parametrize("t_dtype,m_dtype,sigma_dtype", product(*[[np.float32, np.float64]] * 3))
@@ -296,12 +292,8 @@ def test_dmdt_gausses_dtype(t_dtype, m_dtype, sigma_dtype):
     m = np.asarray(t, dtype=m_dtype)
     sigma = np.asarray(t, dtype=sigma_dtype)
     dmdt = DmDt.from_borders(min_lgdt=0, max_lgdt=1, max_abs_dm=1, lgdt_size=2, dm_size=2, norm=[])
-    if t_dtype is m_dtype is sigma_dtype:
-        context = nullcontext()
-    else:
-        context = pytest.raises(TypeError)
-    with context:
-        dmdt.gausses(t, m, sigma)
+    values = dmdt.gausses(t, m, sigma)
+    assert values.dtype == np.result_type(t, m, sigma)
 
 
 @pytest.mark.parametrize("t1_dtype,m1_dtype,t2_dtype,m2_dtype", product(*[[np.float32, np.float64]] * 4))

--- a/light-curve/tests/light_curve_ext/test_feature.py
+++ b/light-curve/tests/light_curve_ext/test_feature.py
@@ -358,20 +358,20 @@ def test_raises_for_wrong_inputs():
     fe = lc.Amplitude()
 
     # First argument
-    with pytest.raises(TypeError, match="'t' has type 'list'"):
-        fe([1.0, 2.0, 3.0], [1.0, 2.0, 3.0])
+    with pytest.raises(TypeError, match="'t' has type 'int'"):
+        fe(5, [1.0, 2.0, 3.0])
     with pytest.raises(TypeError, match="'t' is a 2-d array"):
         fe(np.array([[1.0, 2.0, 3.0]]), np.array([1.0, 2.0, 3.0]))
-    with pytest.raises(TypeError, match="'t' has dtype int64"):
-        fe(np.array([1, 2, 3], dtype=np.int64), np.array([[1.0, 2.0, 3.0]]))
+    with pytest.raises(TypeError, match="'t' has dtype <U1"):
+        fe(np.array(["a", "b", "c"]), np.array([1.0, 2.0, 3.0]))
 
     # Second and third arguments
     t = np.arange(10, dtype=np.float64)
     with pytest.raises(ValueError, match="Mismatched lengths:"):
         fe(t, np.arange(11, dtype=np.float64))
     with pytest.raises(TypeError, match="'m' must be a numpy array"):
-        fe(t, list(t))
+        fe(t, set(t))
     with pytest.raises(TypeError, match="'sigma' is a 0-d array"):
         fe(t, t, np.array(1.0))
     with pytest.raises(TypeError, match="Mismatched dtypes:"):
-        fe(t, t.astype(np.float32))
+        fe(t, t.astype(str) + "x")

--- a/light-curve/tests/light_curve_ext/test_feature.py
+++ b/light-curve/tests/light_curve_ext/test_feature.py
@@ -364,6 +364,10 @@ def test_raises_for_wrong_inputs():
         fe(np.array([[1.0, 2.0, 3.0]]), np.array([1.0, 2.0, 3.0]))
     with pytest.raises(TypeError, match="'t' has dtype <U1"):
         fe(np.array(["a", "b", "c"]), np.array([1.0, 2.0, 3.0]))
+    with pytest.raises(TypeError, match="'t' has type 'list'"):
+        fe([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], cast=False)
+    # No failure of the last test with cast=True
+    _ = fe([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], cast=True)
 
     # Second and third arguments
     t = np.arange(10, dtype=np.float64)
@@ -375,3 +379,7 @@ def test_raises_for_wrong_inputs():
         fe(t, t, np.array(1.0))
     with pytest.raises(TypeError, match="Mismatched dtypes:"):
         fe(t, t.astype(str) + "x")
+    with pytest.raises(TypeError, match="Mismatched dtypes:"):
+        fe(t, t.astype(np.float32), cast=False)
+    # No failure of the last test with cast=True
+    _ = fe(t, t.astype(np.float32), cast=True)


### PR DESCRIPTION
Fix #509 for some single light-curve methods