### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,12 +2,16 @@
 
 ## Project Overview
 
-`light-curve-python` is a high-performance Python package for time-series feature extraction, particularly for astrophysical light curves. It's a hybrid Rust/Python project that wraps the [`light-curve-feature`](https://github.com/light-curve/light-curve-feature) and [`light-curve-dmdt`](https://github.com/light-curve/light-curve-dmdt) Rust crates.
+`light-curve-python` is a high-performance Python package for time-series feature extraction, particularly for
+astrophysical light curves. It's a hybrid Rust/Python project that wraps the [
+`light-curve-feature`](https://github.com/light-curve/light-curve-feature) and [
+`light-curve-dmdt`](https://github.com/light-curve/light-curve-dmdt) Rust crates.
 
 ### Key Technologies
+
 - **Primary Language**: Rust (performance-critical feature extraction) + Python (API and experimental features)
 - **Build System**: Maturin (Python-Rust bridge)
-- **Python Support**: Python 3.9+ (including free-threaded 3.13t and 3.14t)
+- **Python Support**: Python 3.10+ (including free-threaded 3.13t and 3.14t)
 - **Testing**: pytest with benchmark support
 - **CI/CD**: GitHub Actions with extensive platform coverage
 
@@ -36,10 +40,10 @@ light-curve-python/
 ### Setting Up Development Environment
 
 1. **Prerequisites**:
-   - Rust toolchain (stable, updated via `rustup`)
-   - Python 3.9+
-   - System dependencies: `libgsl-dev`, FFTW (on Ubuntu/Debian)
-   - Optional: CMake and C++ compiler for Ceres solver support
+    - Rust toolchain (stable, updated via `rustup`)
+    - Python 3.10+
+    - System dependencies: `libgsl-dev`, FFTW (on Ubuntu/Debian)
+    - Optional: CMake and C++ compiler for Ceres solver support
 
 2. **Initial Setup**:
    ```bash
@@ -58,18 +62,21 @@ light-curve-python/
 ### Building and Testing
 
 #### Build Commands
+
 - **Development build**: `maturin develop` (fast, unoptimized)
 - **Release build**: `maturin develop --release` (slow, optimized)
 - **Rebuild after Rust changes**: Run `maturin develop` again
 - **Python-only changes**: No rebuild needed
 
 #### Running Tests
+
 - **All tests**: `pytest` or `python -m pytest`
 - **With benchmarks**: `pytest --benchmark-enable`
 - **Exclude slow benchmarks (recommended)**: `pytest -m "not (nobs or multi)" --benchmark-enable`
 - **Specific test file**: `pytest tests/test_w_bench.py`
 
 #### Linting and Formatting
+
 - **Python**: `ruff format` and `ruff` (configured in pyproject.toml)
 - **Rust**: `cargo fmt` and `cargo clippy`
 - **Pre-commit**: Automatically runs on commit or via `pre-commit run --all-files`
@@ -77,13 +84,15 @@ light-curve-python/
 ### Code Style and Conventions
 
 #### Python
+
 - **Line length**: 120 characters
-- **Target version**: Python 3.9+
+- **Target version**: Python 3.10+
 - **Formatter**: Ruff format
 - **Linter**: Ruff
 - Follow existing patterns in `light_curve_py/` for experimental features
 
 #### Rust
+
 - **Edition**: 2024
 - **MSRV**: 1.85 (check `Cargo.toml` for current version)
 - **Formatter**: `rustfmt` (standard configuration)
@@ -93,6 +102,7 @@ light-curve-python/
 ### Cargo Features
 
 The package has several compile-time features (see `Cargo.toml`):
+
 - `abi3` (default): CPython ABI3 compatibility for stable Python ABI
 - `ceres-source` (default): Ceres solver built from source
 - `mkl`: Intel MKL for FFTW-based fast periodogram (recommended for Intel CPUs)
@@ -104,35 +114,41 @@ When suggesting build commands, consider: `--no-default-features --features=...`
 ## Testing Requirements
 
 ### Test Coverage
+
 - All new features must have tests
 - Python tests live in `light-curve/tests/`
 - Use `pytest-subtests` for parameterized tests
 - Include docstring examples that can be tested with `markdown-pytest`
 
 ### Benchmark Tests
+
 - Located in `tests/test_w_bench.py`
 - Use `pytest-benchmark` for performance testing
 - Mark slow benchmarks with `@pytest.mark.nobs` or `@pytest.mark.multi`
 
 ### Documentation Tests
+
 - README examples are tested via `markdown-pytest`
 - Use `<!-- name: test_name -->` comments before code blocks to enable testing
 
 ## Important Considerations
 
 ### Performance
+
 - Rust implementation is 1.5-50× faster than pure Python
 - Use Rust for performance-critical features
 - Python implementation (`light_curve_py`) is for experimental features and testing
 - Consider multithreading via `.many()` method for batch processing
 
 ### Compatibility
-- Support Python 3.9-3.14 (including free-threaded variants)
+
+- Support Python 3.10-3.14 (including free-threaded variants)
 - Maintain backward compatibility
 - Test on multiple platforms: Linux (x86_64, aarch64), macOS, Windows
 - ABI3 wheels ensure forward compatibility with future Python versions
 
 ### Dependencies
+
 - **Rust dependencies**: Managed via `Cargo.toml`, keep `Cargo.lock` committed
 - **Python dependencies**: Minimal required (`numpy`), optional extras (`full`, `test`, `dev`)
 - System dependencies required: GSL (optional but default)
@@ -142,23 +158,23 @@ When suggesting build commands, consider: `--no-default-features --features=...`
 ### Adding a New Feature Extractor
 
 1. **Rust implementation**:
-   - Typically implemented in the upstream `light-curve-feature` crate
-   - Add Python bindings in `src/` if needed
-   - Export in `src/lib.rs`
+    - Typically implemented in the upstream `light-curve-feature` crate
+    - Add Python bindings in `src/` if needed
+    - Export in `src/lib.rs`
 
 2. **Python wrapper**:
-   - Import in `light_curve/__init__.py`
-   - Add experimental Python version in `light_curve_py/` if needed
+    - Import in `light_curve/__init__.py`
+    - Add experimental Python version in `light_curve_py/` if needed
 
 3. **Tests**:
-   - Add unit tests in `tests/`
-   - Add benchmarks in `tests/test_w_bench.py`
-   - Update README with feature documentation
+    - Add unit tests in `tests/`
+    - Add benchmarks in `tests/test_w_bench.py`
+    - Update README with feature documentation
 
 4. **Documentation**:
-   - Update README.md feature table
-   - Add usage examples
-   - Update CHANGELOG.md
+    - Update README.md feature table
+    - Add usage examples
+    - Update CHANGELOG.md
 
 ### Updating Dependencies
 
@@ -178,15 +194,15 @@ When suggesting build commands, consider: `--no-default-features --features=...`
 ### GitHub Actions Workflows
 
 - **test.yml**: Main test suite
-  - Tests on Ubuntu (x86_64, aarch64) with Python 3.9-3.14
-  - Runs `cargo fmt`, `cargo clippy`, and coverage
-  - Benchmarks with CodSpeed
-  - MSRV verification
+    - Tests on Ubuntu (x86_64, aarch64) with Python 3.10-3.14
+    - Runs `cargo fmt`, `cargo clippy`, and coverage
+    - Benchmarks with CodSpeed
+    - MSRV verification
 
 - **publish.yml**: Package distribution
-  - Builds wheels for multiple platforms/architectures
-  - Publishes to PyPI and TestPyPI
-  - Uses `cibuildwheel` for cross-platform builds
+    - Builds wheels for multiple platforms/architectures
+    - Publishes to PyPI and TestPyPI
+    - Uses `cibuildwheel` for cross-platform builds
 
 ### Working with CI
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,23 +41,23 @@ jobs:
         # * For Windows we support amd64 only
         # * For Linux we support ARM64 and x86_64
         # * For macOS we support x86_64 (macos-15-intel runner) and ARM64 (macos-14 runner)
-        # * We build wheels for CPython only, one per platform, compatible with ABI3.9
+        # * We build wheels for CPython only, one per platform, compatible with ABI3.10
         include:
-          # CPython 3.9
+          # CPython 3.10
           - os: macos-15-intel
-            cibw_build: cp39-macosx_x86_64
+            cibw_build: cp310-macosx_x86_64
           - os: macos-14
-            cibw_build: cp39-macosx_arm64
+            cibw_build: cp310-macosx_arm64
           - os: windows-2025
-            cibw_build: cp39-win_amd64
+            cibw_build: cp310-win_amd64
           - os: ubuntu-24.04
-            cibw_build: cp39-manylinux_x86_64
+            cibw_build: cp310-manylinux_x86_64
           - os: ubuntu-24.04
-            cibw_build: cp39-musllinux_x86_64
+            cibw_build: cp310-musllinux_x86_64
           - os: ubuntu-24.04-arm
-            cibw_build: cp39-manylinux_aarch64
+            cibw_build: cp310-manylinux_aarch64
           - os: ubuntu-24.04-arm
-            cibw_build: cp39-musllinux_aarch64
+            cibw_build: cp310-musllinux_aarch64
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_minor: [ '9', '10', '11', '12', '13', '13t', '14', '14t' ]
+        python_minor: [ '10', '11', '12', '13', '13t', '14', '14t' ]
         os: [ ubuntu-latest ]
         # Just a single ARM worker to be sure that it works
         include:
@@ -193,10 +193,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Set up Python 3.13t
         uses: actions/setup-python@v6
         with:
@@ -225,6 +225,6 @@ jobs:
       - name: Build
         run: |
           rustup default ${{ steps.get_msrv.outputs.msrv }}
-          maturin build -i python3.9
+          maturin build -i python3.10
           maturin build -i python3.13t
           maturin build -i python3.14t

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`light-curve-python` is a hybrid Rust/Python package for time-series feature extraction in astrophysics. It wraps the `light-curve-feature` and `light-curve-dmdt` Rust crates via PyO3/Maturin bindings.
+`light-curve-python` is a hybrid Rust/Python package for time-series feature extraction in astrophysics. It wraps the
+`light-curve-feature` and `light-curve-dmdt` Rust crates via PyO3/Maturin bindings.
 
 ## Repository Layout
 
-The main package lives in `light-curve/` (not the repo root). There's also a thin alias package in `light-curve-python/`.
+The main package lives in `light-curve/` (not the repo root). There's also a thin alias package in
+`light-curve-python/`.
 
 Within `light-curve/`:
+
 - `src/` — Rust PyO3 bindings (`features.rs` is the main file with 40+ feature extractors, `dmdt.rs` for dm-dt maps)
 - `light_curve/` — Python package
-  - `light_curve_py/` — Pure Python experimental feature implementations
-  - `light_curve_ext.py` — Re-exports from compiled Rust extension
-  - `__init__.py` — Imports Python features first, then overrides with faster Rust equivalents
+    - `light_curve_py/` — Pure Python experimental feature implementations
+    - `light_curve_ext.py` — Re-exports from compiled Rust extension
+    - `__init__.py` — Imports Python features first, then overrides with faster Rust equivalents
 - `tests/` — pytest suite
 
 ## Build & Development Commands
@@ -63,15 +66,19 @@ pre-commit run --all-files
 
 ## Architecture Notes
 
-**Import layering**: `__init__.py` imports all Python implementations first, then overwrites them with Rust equivalents. This means Rust features shadow Python ones at runtime, but both exist for testing/comparison.
+**Import layering**: `__init__.py` imports all Python implementations first, then overwrites them with Rust equivalents.
+This means Rust features shadow Python ones at runtime, but both exist for testing/comparison.
 
-**Feature extraction pattern**: Each feature (e.g., `Amplitude`, `BazinFit`, `Periodogram`) is a class with `__call__(t, m, sigma, ...)` for single light curves and `.many(...)` for batch processing with reduced Python-Rust overhead.
+**Feature extraction pattern**: Each feature (e.g., `Amplitude`, `BazinFit`, `Periodogram`) is a class with
+`__call__(t, m, sigma, ...)` for single light curves and `.many(...)` for batch processing with reduced Python-Rust
+overhead.
 
 **Rust edition**: 2024, MSRV 1.85. Clippy treats warnings as errors.
 
-**Cargo features**: `abi3` (stable Python ABI), `ceres-source`/`ceres-system`, `mkl` (Intel MKL for FFTW-based fast periodogram), `gsl`, `mimalloc`. Default features include abi3, ceres-source, gsl, mimalloc.
+**Cargo features**: `abi3` (stable Python ABI), `ceres-source`/`ceres-system`, `mkl` (Intel MKL for FFTW-based fast
+periodogram), `gsl`, `mimalloc`. Default features include abi3, ceres-source, gsl, mimalloc.
 
-**Code style**: Line length 120, Python target 3.9+, Ruff for Python linting (rules: F, E, W, I001, NPY201).
+**Code style**: Line length 120, Python target 3.10+, Ruff for Python linting (rules: F, E, W, I001, NPY201).
 
 ## Adding a New Feature Extractor
 

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -27,7 +27,7 @@ codegen-units = 1
 
 [features]
 default = ["abi3", "ceres-source", "gsl", "mimalloc"]
-abi3 = ["pyo3/abi3-py39"]
+abi3 = ["pyo3/abi3-py310"]
 ceres-source = ["light-curve-feature/ceres-source"]
 ceres-system = ["light-curve-feature/ceres-system"]
 mkl = ["light-curve-feature/fftw-mkl"]

--- a/light-curve/README.md
+++ b/light-curve/README.md
@@ -22,7 +22,7 @@ conda install -c conda-forge light-curve-python
 features.
 We also provide `light-curve-python` package which is just an "alias" to the main `light-curve[full]` package.
 
-The minimum supported Python version is 3.9.
+The minimum supported Python version is 3.10.
 We provide binary CPython distributions via [PyPI](https://pypi.org/project/light-curve/)
 and [Anaconda](https://anaconda.org/conda-forge/light-curve-python) for various platforms and architectures.
 On PyPI, we provide binary wheels for the stable CPython ABI, ensuring compatibility with future
@@ -675,7 +675,7 @@ assert_array_equal(actual, desired)
 
 ### Prepare environment
 
-Install a recent Rust toolchain and Python 3.9 or higher.
+Install a recent Rust toolchain and Python 3.10 or higher.
 It is recommended to use [`rustup`](https://rustup.rs/) to install Rust toolchain and update it with
 `rustup update` periodically.
 
@@ -792,7 +792,7 @@ from [the list of supported](https://cibuildwheel.pypa.io/en/stable/options/#bui
 
 ```bash
 python -mpip install cibuildwheel
-python -m cibuildwheel --only=cp39-manylinux_x86_64
+python -m cibuildwheel --only=cp310-manylinux_x86_64
 ```
 
 Please notice that we use different Cargo feature set for different platforms, which is defined in
@@ -806,11 +806,11 @@ dependent libraries installed from `homebrew` are built with this target:
 
 ```bash
 export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | awk -F '.' '{print $1"."0}')
-python -m cibuildwheel --only=cp39-macosx_arm64
+python -m cibuildwheel --only=cp310-macosx_arm64
 unset MACOSX_DEPLOYMENT_TARGET
 ```
 
-Since we use ABI3 compatibility, you can build wheels for a single CPython version (currently 3.9+) and they
+Since we use ABI3 compatibility, you can build wheels for a single CPython version (currently 3.10+) and they
 will work with any later version of CPython.
 
 ## Citation

--- a/light-curve/pyproject.toml
+++ b/light-curve/pyproject.toml
@@ -5,13 +5,12 @@ build-backend = "maturin"
 [project]
 name = "light-curve"
 dependencies = ["numpy"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -89,7 +88,7 @@ macos-deployment-target = "10.9"
 
 [tool.black]
 line-length = 120
-target-version = ["py39"]
+target-version = ["py310"]
 include = '\.py$'
 exclude = '''
      /(
@@ -122,7 +121,7 @@ exclude = [
     ".tox",
     "_build",
 ]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [
@@ -160,10 +159,10 @@ markers = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{39,310,311,312,313,313t,314,314t}-{base,test}
+envlist = py{310,311,312,313,313t,314,314t}-{base,test}
 isolated_build = True
 
-[testenv:py{39,310,311,312,313,313t,314,314t}-base]
+[testenv:py{310,311,312,313,313t,314,314t}-base]
 change_dir = {envtmpdir}
 extras =
 commands =
@@ -171,7 +170,7 @@ commands =
 set_env =
     CARGO_TARGET_DIR = {tox_root}/target
 
-[testenv:py{39,310,311,312,313,314}-test]
+[testenv:py{310,311,312,313,314}-test]
 extras = dev
 commands =
     pytest README.md tests/ light_curve/


### PR DESCRIPTION
CI has started to fail, and CPython 3.9 is EOL, so let's just drop it.