### PR TITLE
build: move dev dependencies to [dependency-groups] (PEP 735)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,7 +51,8 @@ light-curve-python/
    python3 -m venv venv
    source venv/bin/activate
    pip install maturin
-   maturin develop --extras=dev
+   pip install --group dev
+   maturin develop
    ```
 
 3. **Installing pre-commit hooks**:
@@ -150,7 +151,7 @@ When suggesting build commands, consider: `--no-default-features --features=...`
 ### Dependencies
 
 - **Rust dependencies**: Managed via `Cargo.toml`, keep `Cargo.lock` committed
-- **Python dependencies**: Minimal required (`numpy`), optional extras (`full`, `test`, `dev`)
+- **Python dependencies**: Minimal required (`numpy`), optional extras (`full`, `test`), and PEP 735 dependency groups (`dev`, `dev-free-threading`)
 - System dependencies required: GSL (optional but default)
 
 ## Common Tasks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ All commands run from `light-curve/` directory:
 ```bash
 # Setup
 pip install maturin
-maturin develop --extras=dev          # Dev build with test dependencies
+pip install --group dev               # Install dev dependencies (PEP 735 group)
+maturin develop                       # Dev build
 maturin develop --release             # Optimized build
 
 # After Rust changes, re-run maturin develop. Python-only changes need no rebuild.

--- a/light-curve/README.md
+++ b/light-curve/README.md
@@ -919,14 +919,16 @@ Install the package in editable mode (see [Build from source](#build-from-source
 
 ```bash
 python -mpip install maturin
+# Install dev dependencies (PEP 735 dependency group) and build the package
+python -mpip install --group dev
 # --release takes longer to build but produces a faster package
 # Add other Cargo flags if needed, e.g. --no-default-features --features=ceres-source
-maturin develop --extras=dev
+maturin develop
 ```
 
 On subsequent runs, activate the environment with `source venv/bin/activate` and rebuild Rust code with
-`maturin develop`. Python-only changes require no rebuild. The `--extras=dev` flag is only needed once to
-install development dependencies.
+`maturin develop`. Python-only changes require no rebuild. The `pip install --group dev` step is only
+needed once to install development dependencies.
 
 It is also recommended to install `pre-commit` hooks to keep the codebase clean.
 Install via `pip` (see the [documentation](https://pre-commit.com/#install) for other options), then run:
@@ -937,7 +939,7 @@ pre-commit install
 
 ### Run tests and benchmarks
 
-All test dependencies are installed with `--extras=dev`. Run the tests with:
+All test dependencies are installed via `pip install --group dev` (see above). Run the tests with:
 
 ```bash
 python -mpytest

--- a/light-curve/pyproject.toml
+++ b/light-curve/pyproject.toml
@@ -35,7 +35,11 @@ full = [
     "scipy<2",
 ]
 
-# Testing environment
+# Testing environment. Still an extra because `maturin develop --extras=test`
+# in .github/workflows/test.yml and `cibuildwheel.test-extras` in the wheel
+# test overrides both call it by name; moving it to [dependency-groups] would
+# require updating those invocations (and cibuildwheel's test-groups support).
+# See issue #670.
 test = [
     "pytest",
     "markdown-pytest",
@@ -55,6 +59,11 @@ test = [
     "joblib",
     "pandas<2.3.3",  # >=2.3.3 has no manylinux_2_17 wheels, only manylinux_2_28
 ]
+
+# Dev dependencies moved out of [project.optional-dependencies] and into
+# [dependency-groups] (PEP 735) so they no longer surface as install-time
+# extras (`pip install light-curve[dev]`). See issue #670.
+[dependency-groups]
 dev = [
     "pytest",
     "markdown-pytest",
@@ -191,7 +200,7 @@ set_env =
     CARGO_TARGET_DIR = {tox_root}/target
 
 [testenv:py{310,311,312,313,314}-test]
-extras = dev
+dependency_groups = dev
 commands =
     pytest README.md tests/ light_curve/
     ruff check .
@@ -199,7 +208,7 @@ set_env =
     CARGO_TARGET_DIR = {tox_root}/target
 
 [testenv:py{313,314}t-test]
-extras = dev-free-threading
+dependency_groups = dev-free-threading
 commands =
     pytest README.md tests/ light_curve/ \
         --ignore tests/test_w_bench.py \


### PR DESCRIPTION
## Summary

Move the `dev` and `dev-free-threading` groups out of `[project.optional-dependencies]` into `[dependency-groups]` (PEP 735), so `pip install light-curve[dev]` no longer pulls in contributor tooling as installable extras.

## What changed

- `light-curve/pyproject.toml`:
  - `dev` and `dev-free-threading` moved to a new `[dependency-groups]` table.
  - Tox `[testenv:*-test]` envs switched from `extras = dev` / `dev-free-threading` to `dependency_groups = dev` / `dev-free-threading` (tox 4 supports PEP 735 groups natively).
- `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md`:
  - Dev setup now uses `pip install --group dev` followed by `maturin develop` instead of `maturin develop --extras=dev`. Maturin doesn't currently expose a CLI flag for dependency-groups, so the install step gets its own line. Functionally equivalent; one extra command for new contributors.

## What stayed

The `test` extra is still in `[project.optional-dependencies]` in this PR because:

- `.github/workflows/test.yml` runs `maturin develop --extras=test` at lines 142 and 181.
- `cibuildwheel` test overrides at the bottom of `pyproject.toml` use `test-extras = ["test"]`.

Moving `test` too would require updating those invocations. cibuildwheel 2.22+ supports `test-groups = [...]`, and the workflow could switch to `pip install --group test .` then `maturin develop`, but that's a slightly larger change with CI-visible blast radius. Happy to do it in a follow-up PR if you want `test` gone from extras too.

## Test plan

- `dev` / `dev-free-threading` no longer show up under `pip install light-curve[<extra>]`.
- `tox -e py313-test` (and friends) still resolve dependencies, now via the dependency group instead of the extra.
- New contributor path matches the updated README: `pip install --group dev && maturin develop`.

Refs #670
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
