### PR TITLE
UV extincted BB option for Rainbow

### DIFF
--- a/light-curve/light_curve/light_curve_py/features/rainbow/_base.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/_base.py
@@ -15,11 +15,8 @@ from light_curve.light_curve_py.minuit_ml import MaximumLikelihood
 __all__ = ["BaseRainbowFit"]
 
 
-# CODATA 2018, grab from astropy
-planck_constant = 6.62607004e-27  # erg s
-speed_of_light = 2.99792458e10  # cm/s
-boltzman_constant = 1.380649e-16  # erg/K
 sigma_sb = 5.6703744191844314e-05  # erg/(cm^2 s K^4)
+speed_of_light = 2.99792458e10  # cm/s
 
 
 IMINUIT_IMPORT_ERROR = (
@@ -69,6 +66,12 @@ class BaseRainbowFit(BaseMultiBandFeature):
         """Temperature parameter names."""
         return NotImplementedError
 
+    @staticmethod
+    @abstractmethod
+    def _spectral_parameter_names() -> List[str]:
+        """Spectral model parameter names."""
+        return NotImplementedError
+
     def __post_init__(self) -> None:
         super().__post_init__()
 
@@ -81,6 +84,7 @@ class BaseRainbowFit(BaseMultiBandFeature):
             common=self._common_parameter_names(),
             bol=self._bolometric_parameter_names(),
             temp=self._temperature_parameter_names(),
+            spec=self._spectral_parameter_names(),
             bands=self.bands,
             with_baseline=self.with_baseline,
         )
@@ -207,14 +211,6 @@ class BaseRainbowFit(BaseMultiBandFeature):
             cov[:, i] *= scale
             cov[i, :] *= scale
 
-    @staticmethod
-    def planck_nu(wave_cm, T):
-        """Planck function in frequency units."""
-        nu = speed_of_light / wave_cm
-        return (
-            (2 * planck_constant / speed_of_light**2) * nu**3 / np.expm1(planck_constant * nu / (boltzman_constant * T))
-        )
-
     def _lsq_model_no_baseline(self, x, *params):
         """Model function for the fit."""
         t, _band_idx, wave_cm = x
@@ -228,7 +224,8 @@ class BaseRainbowFit(BaseMultiBandFeature):
         # peak_nu =  2.821 * boltzman_constant * temp / planck_constant # Wien displacement law
         # norm = self.planck_nu(speed_of_light / peak_nu, temp) # Peak = 1 normalization
 
-        planck = self.planck_nu(wave_cm, temp) / norm
+        spectral = self.spectral_func(wave_cm, temp, params)
+        planck = spectral / norm
 
         flux = planck * bol
 

--- a/light-curve/light_curve/light_curve_py/features/rainbow/_parameters.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/_parameters.py
@@ -29,6 +29,7 @@ def create_parameters_class(
     common: List[str],
     bol: List[str],
     temp: List[str],
+    spec: List[str],
     bands: Bands,
     with_baseline: bool,
 ):
@@ -37,20 +38,22 @@ def create_parameters_class(
     Parameters
     ----------
     cls_name : str
-        Name of the class to create
+        Name of the class to create.
     common : list of str
-        Common parameters for both bolometric and temperature models
+        Common parameters for both bolometric and temperature models.
     bol : list of str
-        Bolometric model parameters, without common parameters
+        Bolometric model parameters, without common parameters.
     temp : list of str
-        Temperature model parameters, without common parameters
+        Temperature model parameters, without common parameters.
+    spec : list of str
+        Spectral model parameters.
     bands : list of str
         Unique list of bands in the dataset. It is used to generate baseline
         parameters when `with_baseline` is True.
     with_baseline : bool
         Whether to include baseline parameters, one per band in `bands`.
     """
-    attributes = common + bol + temp
+    attributes = common + bol + temp + spec
     if with_baseline:
         baseline = list(map(baseline_parameter_name, bands.names))
         attributes += baseline
@@ -61,14 +64,19 @@ def create_parameters_class(
     enum.common_idx = np.array([enum[attr] for attr in common])
 
     enum.bol = bol
-    enum.bol_idx = np.array([enum[attr] for attr in enum.bol])
+    enum.bol_idx = np.array([enum[attr] for attr in enum.bol], dtype=np.int64)
     enum.all_bol = common + bol
-    enum.all_bol_idx = np.array([enum[attr] for attr in enum.all_bol])
+    enum.all_bol_idx = np.array([enum[attr] for attr in enum.all_bol], dtype=np.int64)
 
     enum.temp = temp
-    enum.temp_idx = np.array([enum[attr] for attr in enum.temp])
+    enum.temp_idx = np.array([enum[attr] for attr in enum.temp], dtype=np.int64)
     enum.all_temp = common + temp
-    enum.all_temp_idx = np.array([enum[attr] for attr in enum.all_temp])
+    enum.all_temp_idx = np.array([enum[attr] for attr in enum.all_temp], dtype=np.int64)
+
+    enum.spec = spec
+    enum.spec_idx = np.array([enum[attr] for attr in enum.spec], dtype=np.int64)
+    enum.all_spec = spec
+    enum.all_spec_idx = np.array([enum[attr] for attr in enum.all_spec], dtype=np.int64)
 
     enum.with_baseline = with_baseline
     if with_baseline:

--- a/light-curve/light_curve/light_curve_py/features/rainbow/generic.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/generic.py
@@ -5,6 +5,7 @@ from light_curve.light_curve_py.dataclass_field import dataclass_field
 from light_curve.light_curve_py.features.rainbow._base import BaseRainbowFit
 
 from .bolometric import BaseBolometricTerm, bolometric_terms
+from .spectral import BaseSpectralTerm, spectral_terms
 from .temperature import BaseTemperatureTerm, temperature_terms
 
 __all__ = ["RainbowFit"]
@@ -59,8 +60,15 @@ class RainbowFit(BaseRainbowFit):
 
     bolometric: Union[str, BaseBolometricTerm] = dataclass_field(default="bazin", kw_only=True)
     """Which parametric bolometric term to use"""
+
     temperature: Union[str, BaseTemperatureTerm] = dataclass_field(default="sigmoid", kw_only=True)
     """Which parametric temperature term to use"""
+
+    spectral: Union[str, BaseSpectralTerm] = dataclass_field(
+        default="planck",
+        kw_only=True,
+    )
+    """Which spectral term to use"""
 
     def __post_init__(self):
         if not isinstance(self.bolometric, BaseBolometricTerm):
@@ -68,6 +76,9 @@ class RainbowFit(BaseRainbowFit):
 
         if not isinstance(self.temperature, BaseTemperatureTerm):
             self.temperature = temperature_terms[self.temperature]
+
+        if not isinstance(self.spectral, BaseSpectralTerm):
+            self.spectral = spectral_terms[self.spectral]
 
         super().__post_init__()
 
@@ -84,16 +95,22 @@ class RainbowFit(BaseRainbowFit):
         temperature_parameters = self.temperature.parameter_names()
         return [i for i in temperature_parameters if i not in self._common_parameter_names()]
 
+    def _spectral_parameter_names(self) -> List[str]:
+        return self.spectral.parameter_names()
+
     def bol_func(self, t, params):
         return self.bolometric.value(t, *params[self.p.all_bol_idx])
 
     def temp_func(self, t, params):
         return self.temperature.value(t, *params[self.p.all_temp_idx])
 
+    def spectral_func(self, wave_cm, T, params):
+        return self.spectral.value(wave_cm, T, *params[self.p.all_spec_idx])
+
     def _parameter_scalings(self) -> Dict[str, str]:
         rules = super()._parameter_scalings()
 
-        for term in [self.bolometric, self.temperature]:
+        for term in [self.bolometric, self.temperature, self.spectral]:
             for name, scaling in zip(term.parameter_names(), term.parameter_scalings()):
                 rules[name] = scaling
 
@@ -102,12 +119,14 @@ class RainbowFit(BaseRainbowFit):
     def _initial_guesses(self, t, m, sigma, band) -> Dict[str, float]:
         initial = self.bolometric.initial_guesses(t, m, sigma, band)
         initial.update(self.temperature.initial_guesses(t, m, sigma, band))
+        initial.update(self.spectral.initial_guesses(t, m, sigma, band))
 
         return initial
 
     def _limits(self, t, m, sigma, band) -> Dict[str, Tuple[float, float]]:
         limits = self.bolometric.limits(t, m, sigma, band)
         limits.update(self.temperature.limits(t, m, sigma, band))
+        limits.update(self.spectral.limits(t, m, sigma, band))
 
         return limits
 

--- a/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
@@ -1,0 +1,123 @@
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Dict, List, Union
+
+import numpy as np
+
+__all__ = [
+    "spectral_terms",
+    "BaseSpectralTerm",
+    "PlanckSpectralTerm",
+    "BlanketedPlanckSpectralTerm",
+]
+
+# CODATA 2018
+planck_constant = 6.62607004e-27  # erg s
+speed_of_light = 2.99792458e10  # cm/s
+boltzman_constant = 1.380649e-16  # erg/K
+
+
+@dataclass()
+class BaseSpectralTerm:
+    """Spectral term for Rainbow"""
+
+    @staticmethod
+    @abstractmethod
+    def parameter_names() -> List[str]:
+        return NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def parameter_scalings() -> List[Union[str, None]]:
+        return NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def value(wave_cm, T, *params):
+        return NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def initial_guesses(t, m, sigma, band) -> Dict[str, float]:
+        return NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def limits(t, m, sigma, band) -> Dict[str, float]:
+        return NotImplementedError
+
+
+@dataclass()
+class PlanckSpectralTerm(BaseSpectralTerm):
+    """Standard blackbody spectrum"""
+
+    @staticmethod
+    def parameter_names():
+        return []
+
+    @staticmethod
+    def parameter_scalings():
+        return []
+
+    @staticmethod
+    def value(wave_cm, T, *params):
+        nu = speed_of_light / wave_cm
+
+        return (
+            (2 * planck_constant / speed_of_light**2) * nu**3 / np.expm1(planck_constant * nu / (boltzman_constant * T))
+        )
+
+    @staticmethod
+    def initial_guesses(t, m, sigma, band):
+        return {}
+
+    @staticmethod
+    def limits(t, m, sigma, band):
+        return {}
+
+
+@dataclass()
+class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
+    """Blackbody spectrum with exponential blanketing"""
+
+    @staticmethod
+    def parameter_names():
+        return ["intensity", "l0"]
+
+    @staticmethod
+    def parameter_scalings():
+        return [None, None]
+
+    @staticmethod
+    def value(wave_cm, T, intensity, l0):
+        base = PlanckSpectralTerm.value(wave_cm, T)
+
+        # l0 is expressed in Angstrom
+        l0_cm = l0 * 1e-8
+
+        tau = 10**intensity * np.exp(-wave_cm / l0_cm)
+
+        return base * np.exp(-tau)
+
+    @staticmethod
+    def initial_guesses(t, m, sigma, band):
+        return {
+            "intensity": 1.0,
+            "l0": 100.0,
+        }
+
+    @staticmethod
+    def limits(t, m, sigma, band):
+        # l0 and intensity are degenerate. Putting either to ~0 leads to a classical BB.
+        # We prevent intensity to go to 0, because the blanketing is more physically realistic
+        # at low l0 high intensity rather than high l0 low intensity.
+        return {
+            "intensity": (1.5, 6.0),
+            "l0": (100.0, 2000.0),
+        }
+
+
+spectral_terms = {
+    "planck": PlanckSpectralTerm,
+    "blanketed": BlanketedPlanckSpectralTerm,
+}

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -1,126 +1,317 @@
+import matplotlib.pyplot as plt
 import numpy as np
 
 from light_curve.light_curve_py import RainbowFit
 from light_curve.light_curve_py.features.rainbow._scaler import MultiBandScaler
 
 
-def test_noisy_with_baseline():
+def test_noisy_with_baseline(plot=False):
+
     rng = np.random.default_rng(0)
 
-    band_wave_aa = {"g": 4770.0, "r": 6231.0, "i": 7625.0, "z": 9134.0}
+    band_wave_aa = {
+        "g": 4770.0,
+        "r": 6231.0,
+        "i": 7625.0,
+        "z": 9134.0,
+    }
 
     reference_time = 60000.0
     amplitude = 1.0
     rise_time = 5.0
     fall_time = 30.0
+
     Tmin = 5e3
     Tmax = 15e3
     t_color = 10
+
+    intensity = 3.0
+    l0 = 500.0
+
     baselines = {b: 0.3 * amplitude + rng.exponential(scale=0.3 * amplitude) for b in band_wave_aa}
 
-    expected = [reference_time, amplitude, rise_time, fall_time, Tmin, Tmax, t_color, *baselines.values(), 1.0]
+    expected = [
+        reference_time,
+        amplitude,
+        rise_time,
+        fall_time,
+        Tmin,
+        Tmax,
+        t_color,
+        intensity,
+        l0,
+        *baselines.values(),
+        1.0,
+    ]
 
-    feature = RainbowFit.from_angstrom(band_wave_aa, with_baseline=True, temperature="sigmoid", bolometric="bazin")
+    feature = RainbowFit.from_angstrom(
+        band_wave_aa,
+        with_baseline=True,
+        temperature="sigmoid",
+        bolometric="bazin",
+        spectral="blanketed",
+    )
 
-    t = np.sort(rng.uniform(reference_time - 3 * rise_time, reference_time + 3 * fall_time, 1000))
+    t = np.sort(
+        rng.uniform(
+            reference_time - 3 * rise_time,
+            reference_time + 3 * fall_time,
+            1000,
+        )
+    )
+
     band = rng.choice(list(band_wave_aa), size=len(t))
 
-    flux = feature.model(t, band, *expected)
-    # S/N = 10 for minimum flux, scale for Poisson noise
-    flux_err = np.sqrt(flux * np.min(flux)) / 10.0
+    flux = feature.model(t, band, *expected[:-1])
+
+    protected_flux = np.where(flux > 1e-3, flux, 1e-3)
+
+    flux_err = np.sqrt(protected_flux * np.min(protected_flux)) / 10.0
+
     flux += rng.normal(0.0, flux_err)
 
-    actual = feature(t, flux, sigma=flux_err, band=band)
+    actual = feature(
+        t,
+        flux,
+        sigma=flux_err,
+        band=band,
+    )
 
-    # import matplotlib.pyplot as plt
-    # plt.scatter(t, flux, s=5, label="data")
-    # plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
-    # plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
-    # plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
-    # plt.legend()
-    # plt.show()
+    if plot:
+        colors = {
+            "g": "blue",
+            "r": "green",
+            "i": "orange",
+            "z": "red",
+        }
 
-    np.testing.assert_allclose(feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1)
+        plt.figure(figsize=(12, 5))
+
+        for b in band_wave_aa:
+            mask = band == b
+
+            plt.errorbar(
+                t[mask],
+                flux[mask],
+                yerr=flux_err[mask],
+                ls="none",
+                fmt=".",
+                alpha=0.3,
+                color=colors[b],
+            )
+
+            plt.plot(
+                t[mask],
+                feature.model(t[mask], band[mask], *expected[:-1]),
+                color=colors[b],
+                linewidth=2,
+                label=f"{b} expected",
+            )
+
+            plt.plot(
+                t[mask],
+                feature.model(t[mask], band[mask], *actual[:-1]),
+                "--",
+                color=colors[b],
+                linewidth=2,
+                label=f"{b} fitted",
+            )
+
+        plt.legend()
+        plt.title("Blanketed model with baseline")
+        plt.xlabel("time")
+        plt.ylabel("flux")
+        plt.show()
+
+    np.testing.assert_allclose(
+        feature.model(t, band, *expected[:-1]),
+        feature.model(t, band, *actual[:-1]),
+        rtol=0.1,
+    )
 
 
-def test_noisy_all_functions_combination():
+def test_noisy_all_functions_combination(plot=False):
+
     rng = np.random.default_rng(0)
-    band_wave_aa = {"g": 4770.0, "r": 6231.0, "i": 7625.0, "z": 9134.0}
+
+    band_wave_aa = {
+        "g": 4770.0,
+        "r": 6231.0,
+        "i": 7625.0,
+        "z": 9134.0,
+    }
+
     t = np.sort(rng.uniform(59985.0, 60090.0, 1000))
+
     band = rng.choice(list(band_wave_aa), size=len(t))
 
+    # ======================================================
+    # Bolometric models
+    # ======================================================
+
     bazin_parameters = [
-        60000.0,  # reference_time
-        1.0,  # amplitude
-        5.0,  # rise_time
-        30.0,  # fall_time
+        60000.0,
+        1.0,
+        5.0,
+        30.0,
     ]
 
     sigmoid_parameters = [
-        60000.0,  # reference_time
-        1.0,  # amplitude
-        5.0,  # rise_time
+        60000.0,
+        1.0,
+        5.0,
     ]
 
     linexp_parameters = [
-        60000.0,  # reference_time
-        1,  # amplitude
-        -20,  # rise_time
+        60000.0,
+        1,
+        -20,
     ]
 
-    doublexp_parameters = [60000.0, 10, 5, 10, 0.1]  # reference_time  # amplitude  # time1  # time2  # p
+    doublexp_parameters = [
+        60000.0,
+        10,
+        5,
+        10,
+        0.1,
+    ]
 
-    bolometric_names = ["bazin", "sigmoid", "linexp", "doublexp"]
-    bolometric_params = [bazin_parameters, sigmoid_parameters, linexp_parameters, doublexp_parameters]
+    bolometric_names = [
+        "bazin",
+        "sigmoid",
+        "linexp",
+        "doublexp",
+    ]
 
-    Tsigmoid_parameters = [5e3, 15e3, 10]  # Tmin  # Tmax  # t_color
+    bolometric_params = [
+        bazin_parameters,
+        sigmoid_parameters,
+        linexp_parameters,
+        doublexp_parameters,
+    ]
 
-    constant_parameters = [1e4]  # T
+    # ======================================================
+    # Temperature models
+    # ======================================================
 
-    temperature_names = ["constant", "sigmoid"]
-    temperature_params = [constant_parameters, Tsigmoid_parameters]
+    Tsigmoid_parameters = [
+        5e3,
+        15e3,
+        10,
+    ]
+
+    constant_parameters = [
+        1e4,
+    ]
+
+    temperature_names = [
+        "constant",
+        "sigmoid",
+    ]
+
+    temperature_params = [
+        constant_parameters,
+        Tsigmoid_parameters,
+    ]
+
+    # ======================================================
+    # Spectral models
+    # ======================================================
+
+    spectral_names = [
+        "planck",
+        "blanketed",
+    ]
+
+    spectral_params = [
+        [],
+        [3.0, 750.0],  # intensity, l0
+    ]
+
+    # ======================================================
+    # Loop over all combinations
+    # ======================================================
 
     for idx_b in range(len(bolometric_names)):
         for idx_t in range(len(temperature_names)):
-            expected = [*bolometric_params[idx_b], *temperature_params[idx_t], 1.0]
+            for idx_s in range(len(spectral_names)):
+                expected = [
+                    *bolometric_params[idx_b],
+                    *temperature_params[idx_t],
+                    *spectral_params[idx_s],
+                    1.0,
+                ]
 
-            feature = RainbowFit.from_angstrom(
-                band_wave_aa,
-                with_baseline=False,
-                temperature=temperature_names[idx_t],
-                bolometric=bolometric_names[idx_b],
-            )
+                feature = RainbowFit.from_angstrom(
+                    band_wave_aa,
+                    with_baseline=False,
+                    temperature=temperature_names[idx_t],
+                    bolometric=bolometric_names[idx_b],
+                    spectral=spectral_names[idx_s],
+                )
 
-            flux = feature.model(t, band, *expected)
+                flux = feature.model(t, band, *expected[:-1])
 
-            # The linexp function can reach unphysical negative flux values
-            protected_flux = np.where(flux > 1e-3, flux, 1e-3)
+                protected_flux = np.where(
+                    flux > 1e-3,
+                    flux,
+                    1e-3,
+                )
 
-            # S/N = 10 for minimum flux, scale for Poisson noise
-            flux_err = np.sqrt(protected_flux * np.min(protected_flux)) / 10.0
-            flux += rng.normal(0.0, flux_err)
+                flux_err = np.sqrt(protected_flux * np.min(protected_flux)) / 10.0
 
-            actual = feature(t, flux, sigma=flux_err, band=band)
+                flux += rng.normal(0.0, flux_err)
 
-            # import matplotlib.pyplot as plt
-            # plt.figure()
-            # plt.scatter(t, flux, s=5, label="data")
-            # plt.errorbar(t, flux, yerr=flux_err, ls="none", capsize=1)
-            # plt.plot(t, feature.model(t, band, *expected), "x", label="expected")
-            # plt.plot(t, feature.model(t, band, *actual), "*", label="actual")
-            # plt.ylim(-.05, flux.max()+0.1)
-            # plt.legend()
-            # plt.show()
+                actual = feature(
+                    t,
+                    flux,
+                    sigma=flux_err,
+                    band=band,
+                )
 
-            # The first test might be too rigid. The second test allow for good local minima to be accepted
-            np.testing.assert_allclose(actual[:-1], expected[:-1], rtol=0.1)
+                if plot:
+                    plt.figure(figsize=(10, 4))
 
-            # If either the absolute or the relative test passes, it is accepted.
-            # It prevents linexp, which include a flat exactly 0 baseline to not pass the test because
-            # of very minor parameter differences that lead to a major relative difference.
-            np.testing.assert_allclose(
-                feature.model(t, band, *expected), feature.model(t, band, *actual), rtol=0.1, atol=0.1, strict=False
-            )
+                    plt.scatter(
+                        t,
+                        flux,
+                        s=5,
+                        alpha=0.4,
+                        label="data",
+                    )
+
+                    plt.plot(
+                        t,
+                        feature.model(t, band, *expected[:-1]),
+                        "x",
+                        label="expected",
+                    )
+
+                    plt.plot(
+                        t,
+                        feature.model(t, band, *actual[:-1]),
+                        ".",
+                        label="actual",
+                    )
+
+                    plt.title(f"{bolometric_names[idx_b]} + {temperature_names[idx_t]} + {spectral_names[idx_s]}")
+
+                    plt.legend()
+                    plt.show()
+
+                np.testing.assert_allclose(
+                    actual[:-1],
+                    expected[:-1],
+                    rtol=0.1,
+                )
+
+                np.testing.assert_allclose(
+                    feature.model(t, band, *expected[:-1]),
+                    feature.model(t, band, *actual[:-1]),
+                    rtol=0.1,
+                    atol=0.1,
+                    strict=False,
+                )
 
 
 def test_scaler_from_flux_list_input():

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -1,11 +1,11 @@
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
 import numpy as np
 
 from light_curve.light_curve_py import RainbowFit
 from light_curve.light_curve_py.features.rainbow._scaler import MultiBandScaler
 
 
-def test_noisy_with_baseline(plot=False):
+def test_noisy_with_baseline():
 
     rng = np.random.default_rng(0)
 
@@ -77,51 +77,52 @@ def test_noisy_with_baseline(plot=False):
         band=band,
     )
 
-    if plot:
-        colors = {
-            "g": "blue",
-            "r": "green",
-            "i": "orange",
-            "z": "red",
-        }
+    """
+    colors = {
+        "g": "blue",
+        "r": "green",
+        "i": "orange",
+        "z": "red",
+    }
 
-        plt.figure(figsize=(12, 5))
+    plt.figure(figsize=(12, 5))
 
-        for b in band_wave_aa:
-            mask = band == b
+    for b in band_wave_aa:
+        mask = band == b
 
-            plt.errorbar(
-                t[mask],
-                flux[mask],
-                yerr=flux_err[mask],
-                ls="none",
-                fmt=".",
-                alpha=0.3,
-                color=colors[b],
-            )
+        plt.errorbar(
+            t[mask],
+            flux[mask],
+            yerr=flux_err[mask],
+            ls="none",
+            fmt=".",
+            alpha=0.3,
+            color=colors[b],
+        )
 
-            plt.plot(
-                t[mask],
-                feature.model(t[mask], band[mask], *expected[:-1]),
-                color=colors[b],
-                linewidth=2,
-                label=f"{b} expected",
-            )
+        plt.plot(
+            t[mask],
+            feature.model(t[mask], band[mask], *expected[:-1]),
+            color=colors[b],
+            linewidth=2,
+            label=f"{b} expected",
+        )
 
-            plt.plot(
-                t[mask],
-                feature.model(t[mask], band[mask], *actual[:-1]),
-                "--",
-                color=colors[b],
-                linewidth=2,
-                label=f"{b} fitted",
-            )
+        plt.plot(
+            t[mask],
+            feature.model(t[mask], band[mask], *actual[:-1]),
+            "--",
+            color=colors[b],
+            linewidth=2,
+            label=f"{b} fitted",
+        )
 
-        plt.legend()
-        plt.title("Blanketed model with baseline")
-        plt.xlabel("time")
-        plt.ylabel("flux")
-        plt.show()
+    plt.legend()
+    plt.title("Blanketed model with baseline")
+    plt.xlabel("time")
+    plt.ylabel("flux")
+    plt.show()
+    """
 
     np.testing.assert_allclose(
         feature.model(t, band, *expected[:-1]),
@@ -130,7 +131,7 @@ def test_noisy_with_baseline(plot=False):
     )
 
 
-def test_noisy_all_functions_combination(plot=False):
+def test_noisy_all_functions_combination():
 
     rng = np.random.default_rng(0)
 
@@ -269,35 +270,36 @@ def test_noisy_all_functions_combination(plot=False):
                     band=band,
                 )
 
-                if plot:
-                    plt.figure(figsize=(10, 4))
+                """
+                plt.figure(figsize=(10, 4))
 
-                    plt.scatter(
-                        t,
-                        flux,
-                        s=5,
-                        alpha=0.4,
-                        label="data",
-                    )
+                plt.scatter(
+                    t,
+                    flux,
+                    s=5,
+                    alpha=0.4,
+                    label="data",
+                )
 
-                    plt.plot(
-                        t,
-                        feature.model(t, band, *expected[:-1]),
-                        "x",
-                        label="expected",
-                    )
+                plt.plot(
+                    t,
+                    feature.model(t, band, *expected[:-1]),
+                    "x",
+                    label="expected",
+                )
 
-                    plt.plot(
-                        t,
-                        feature.model(t, band, *actual[:-1]),
-                        ".",
-                        label="actual",
-                    )
+                plt.plot(
+                    t,
+                    feature.model(t, band, *actual[:-1]),
+                    ".",
+                    label="actual",
+                )
 
-                    plt.title(f"{bolometric_names[idx_b]} + {temperature_names[idx_t]} + {spectral_names[idx_s]}")
+                plt.title(f"{bolometric_names[idx_b]} + {temperature_names[idx_t]} + {spectral_names[idx_s]}")
 
-                    plt.legend()
-                    plt.show()
+                plt.legend()
+                plt.show()
+                """
 
                 np.testing.assert_allclose(
                     actual[:-1],


### PR DESCRIPTION
Major changes in Rainbow. It now treats the Blackbody part as a parametric model, in the same way the flux evolution and temperature evolution were treated before.

A `spectral.py` file was added, where all SED models should be written. Hence, BB is now just a particular case of SED (with 0 parameters). A phenomenological UV-extincted BB model was also added. It requires fitting 2 parameters, but is able to better model light curves with strong blanketing effect in the u-band (or even more bands in case of high redshift sources).

By default, the SED is chosen to be BB, so previous implementation of Rainbow shouldn't be affected. 

The `tests_rainbow.py` file now also loops on SED models. 