### PR TITLE
Drop CPython 3.13t free-threading support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ astrophysical light curves. It's a hybrid Rust/Python project that wraps the [
 
 - **Primary Language**: Rust (performance-critical feature extraction) + Python (API and experimental features)
 - **Build System**: Maturin (Python-Rust bridge)
-- **Python Support**: Python 3.10+ (including free-threaded 3.13t and 3.14t)
+- **Python Support**: Python 3.10+ (including free-threaded 3.14t)
 - **Testing**: pytest with benchmark support
 - **CI/CD**: GitHub Actions with extensive platform coverage
 
@@ -142,7 +142,7 @@ When suggesting build commands, consider: `--no-default-features --features=...`
 
 ### Compatibility
 
-- Support Python 3.10-3.14 (including free-threaded variants)
+- Support Python 3.10-3.14 (including the free-threaded 3.14 variant)
 - Maintain backward compatibility
 - Test on multiple platforms: Linux (x86_64, aarch64), macOS, Windows
 - ABI3 wheels ensure forward compatibility with future Python versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,10 +196,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - name: Set up Python 3.13t
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13t'
       - name: Set up Python 3.14t
         uses: actions/setup-python@v6
         with:
@@ -225,5 +221,4 @@ jobs:
         run: |
           rustup default ${{ steps.get_msrv.outputs.msrv }}
           maturin build -i python3.10
-          maturin build -i python3.13t
           maturin build -i python3.14t

--- a/light-curve/README.md
+++ b/light-curve/README.md
@@ -1056,10 +1056,8 @@ We no longer publish PyPy wheels ([#345](https://github.com/light-curve/light-cu
 or the PPC64le CPython glibc wheel ([#479](https://github.com/light-curve/light-curve-python/issues/479));
 please open an issue if you need either.
 
-Free-threaded Python
-([experimental in Python 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython),
-[officially supported in Python 3.14+](https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779))
-is supported when built from source.
+Free-threaded Python is supported when built from source for Python 3.14+
+([officially supported in Python 3.14+](https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep779)).
 No pre-built distributions are currently provided; please comment on the relevant issues if you need them:
 [PyPI binary wheel issue](https://github.com/light-curve/light-curve-python/issues/500),
 [conda-forge package issue](https://github.com/conda-forge/light-curve-python-feedstock/issues/11).

--- a/light-curve/pyproject.toml
+++ b/light-curve/pyproject.toml
@@ -179,10 +179,10 @@ markers = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{310,311,312,313,313t,314,314t}-{base,test}
+envlist = py{310,311,312,313,314,314t}-{base,test}
 isolated_build = True
 
-[testenv:py{310,311,312,313,313t,314,314t}-base]
+[testenv:py{310,311,312,313,314,314t}-base]
 change_dir = {envtmpdir}
 extras =
 commands =
@@ -198,7 +198,7 @@ commands =
 set_env =
     CARGO_TARGET_DIR = {tox_root}/target
 
-[testenv:py{313,314}t-test]
+[testenv:py314t-test]
 dependency_groups = dev-free-threading
 commands =
     pytest README.md tests/ light_curve/ \


### PR DESCRIPTION
Fixes #693.

This removes the remaining CPython 3.13t free-threading references while keeping normal Python 3.13 and free-threaded Python 3.14 coverage.

Changes:

- removes `313t` from the tox environment matrix
- drops the `python3.13t` setup/build step from the MSRV build job
- updates README wording to describe free-threaded source builds as Python 3.14+
- updates the repository Copilot instructions so they no longer advertise 3.13t support

Verification:

- `git diff --check`
- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('light-curve/pyproject.toml').read_text()); print('pyproject ok')"`
- `actionlint .github/workflows/test.yml`
- `uvx tox -l`

This was implemented with Codex assistance, with the final diff reviewed manually and kept to the 3.13t/free-threading scope.
