### PR TITLE
ci: cancel outdated Test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: [ push, pull_request, workflow_dispatch ]
 
+concurrency:
+  group: ${{ startsWith(github.ref, 'refs/tags/') && github.run_id || github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   py_build_deps:
     outputs:


### PR DESCRIPTION
## Summary

Adds workflow-level concurrency to the Test workflow so newer commits on the same pull request or branch cancel older in-progress Test runs.

Tag-triggered runs are kept out of the shared cancellation group and set `cancel-in-progress` to false, so release tag executions are not canceled by later runs.

Closes #709.

## Verification

- Parsed `.github/workflows/test.yml` with Python/PyYAML and confirmed the `concurrency` block is present
- `git diff --check`
