### PR TITLE
docs: fix link colors in dark mode (closes #731)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -196,6 +196,15 @@
   .lc-dmdt-s1, .lc-dmdt-s2, .lc-dmdt-s3 { opacity: 0.9 !important; animation: none; }
 }
 
+/* ── Dark mode: use accent (deep-orange) for all links ───────────────── */
+/* In slate+indigo, --md-typeset-a-color defaults to blue — hard to read  */
+/* on the dark indigo backgrounds.  The deep-orange accent has good        */
+/* contrast and is already used as the theme accent colour.                */
+
+[data-md-color-scheme="slate"] {
+  --md-typeset-a-color: var(--md-accent-fg-color);
+}
+
 /* ── Navigation links ──────────────────────────────────────────────── */
 
 /* Left sidebar — non-active links: blue + underline */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -201,7 +201,8 @@
 /* on the dark indigo backgrounds.  The deep-orange accent has good        */
 /* contrast and is already used as the theme accent colour.                */
 
-[data-md-color-scheme="slate"] {
+/* Match Material's two-attribute specificity so our rule wins */
+[data-md-color-scheme="slate"][data-md-color-primary="indigo"] {
   --md-typeset-a-color: var(--md-accent-fg-color);
 }
 


### PR DESCRIPTION
In the slate+indigo dark palette, --md-typeset-a-color defaults to a blue that's nearly invisible on the indigo sidebar/header backgrounds. Override it to var(--md-accent-fg-color) (deep-orange) in dark mode — it already appears as the accent colour and has good contrast.

A single CSS variable override cascades through all link-coloured elements: body content, left sidebar, right TOC, and top tabs.

closes #731 