### PR TITLE
UV extinction now inversely scales with temperature

### DIFF
--- a/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
@@ -92,19 +92,24 @@ class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
     def value(wave_cm, T, lambda_scale):
         base = PlanckSpectralTerm.value(wave_cm, T)
 
-        # Lambda_angstrom represents how far (in wavelength) the extinction affects the BB
-        # Lambda_scale quantifies this between 0 (no UV ext) and 1 (most of high frequencies are suppressed)
-        # Therefore, lambda_angstrom should inversely scale with temperature (width of BB varies)
-        lambda_angstrom = 5e7 * lambda_scale / T
+        # Phenomenological value for the slope of the extinction
+        # No physical reasons for this value, just nice fits
+        # Fitting instead of fixing is likely overkill for broad band photometry
+        intensity = 10**2
+
+        # This empirical constant encodes how far (in wavelength) the maximum UV extinction extends (lambda_scale=1).
+        # The scale of this value comes from how it relates temperature to wavelength in angstrom.
+        # This value allows the extinction to affect the BB wavelength a little over the peak (when used in the formula below).
+        max_extinction = 5e7
+
+        # Lambda_angstrom represents how far (in absolute wavelength) the extinction affects the BB.
+        # Lambda_scale quantifies this between 0 (no UV ext) and 1 maximum allowed suppression (encoded by max_extinction above)
+        # We want this maximum extinction to scale with the size of the BB.
+        # Therefore, lambda_angstrom should inversely scale with temperature.
+        lambda_angstrom = max_extinction * lambda_scale / T
 
         # Convert to cm to match wave_cm
         lambda_cm = lambda_angstrom * 1e-8
-
-        # Phenomenological value for the slope of the extinction
-        # No physical reasons for this value, just nice fits
-        # Could be improved in the future
-        # Fitting instead of fixing is likely overkill for broad band photometry
-        intensity = 10**2
 
         tau = intensity * np.exp(-wave_cm / lambda_cm)
 

--- a/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
@@ -92,8 +92,13 @@ class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
     def value(wave_cm, T, lambda_scale):
         base = PlanckSpectralTerm.value(wave_cm, T)
 
-        # lambda_scale is expressed in Angstrom
-        lambda_scale_cm = lambda_scale * 1e-8
+        # Lambda_angstrom represents how far (in wavelength) the extinction affects the BB
+        # Lambda_scale quantifies this between 0 (no UV ext) and 1 (most of high frequencies are suppressed)
+        # Therefore, lambda_angstrom should inversely scale with temperature (width of BB varies)
+        lambda_angstrom = 5e7 * lambda_scale / T
+
+        # Convert to cm to match wave_cm
+        lambda_cm = lambda_angstrom * 1e-8
 
         # Phenomenological value for the slope of the extinction
         # No physical reasons for this value, just nice fits
@@ -101,20 +106,20 @@ class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
         # Fitting instead of fixing is likely overkill for broad band photometry
         intensity = 10**2
 
-        tau = intensity * np.exp(-wave_cm / lambda_scale_cm)
+        tau = intensity * np.exp(-wave_cm / lambda_cm)
 
         return base * np.exp(-tau)
 
     @staticmethod
     def initial_guesses(t, m, sigma, band):
         return {
-            "lambda_scale": 10.0,
+            "lambda_scale": 0.001,
         }
 
     @staticmethod
     def limits(t, m, sigma, band):
         return {
-            "lambda_scale": (10.0, 1000.0),
+            "lambda_scale": (0.001, 1.0),
         }
 
 

--- a/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
@@ -99,11 +99,11 @@ class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
 
         # This empirical constant encodes how far (in wavelength) the maximum UV extinction extends (lambda_scale=1).
         # The scale of this value comes from how it relates temperature to wavelength in angstrom.
-        # This value allows the extinction to affect the BB wavelength a little over the peak (when used in the formula below).
+        # This value allows the extinction to affect the BB wavelength a little over the peak (in the formula below).
         max_extinction = 5e7
 
         # Lambda_angstrom represents how far (in absolute wavelength) the extinction affects the BB.
-        # Lambda_scale quantifies this between 0 (no UV ext) and 1 maximum allowed suppression (encoded by max_extinction above)
+        # Lambda_scale quantifies this between 0 (no UV ext) and 1 max suppression (encoded by max_extinction above)
         # We want this maximum extinction to scale with the size of the BB.
         # Therefore, lambda_angstrom should inversely scale with temperature.
         lambda_angstrom = max_extinction * lambda_scale / T

--- a/light-curve/tests/light_curve_py/features/test_rainbow.py
+++ b/light-curve/tests/light_curve_py/features/test_rainbow.py
@@ -25,7 +25,7 @@ def test_noisy_with_baseline():
     Tmax = 15e3
     t_color = 10
 
-    lambda_scale = 500.0
+    lambda_scale = 0.1
 
     baselines = {b: 0.3 * amplitude + rng.exponential(scale=0.3 * amplitude) for b in band_wave_aa}
 
@@ -220,7 +220,7 @@ def test_noisy_all_functions_combination():
     BB_parameters = []
 
     UV_BB_parameters = [
-        800.0,  # lambda_scale
+        0.4,  # lambda_scale
     ]
 
     spectral_names = [


### PR DESCRIPTION
UV extinction was improving the fits moderately for high temperature transients, but the UV extinction was negligible for low temperature sources (cold or redshifted sources). 
It was lacking a scaling of the depth of UV extinction as a function of temperature. Now the fits is greatly improved for all kind of temperatures.
lambda_scale is now a float between 0 and 1, indicating how much UV extinction to use, from 0 to a significant part of high frequencies being highly suppressed. 