### PR TITLE
ci: update astral-sh/setup-uv from v5 to v8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,9 +103,67 @@ jobs:
           path: light-curve/target/wheels/
 
 
+  download-hf-models:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cache HuggingFace models
+        id: hf-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-v1
+          save-always: true
+      - name: Set up Python
+        if: steps.hf-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Download models
+        if: steps.hf-cache.outputs.cache-hit != 'true'
+        run: |
+          pip install huggingface_hub
+          python - <<'EOF'
+          from huggingface_hub import hf_hub_download
+          hf_hub_download("light-curve/astromer1", "astromer1.onnx")
+          hf_hub_download("light-curve/astromer2", "astromer2.onnx")
+          hf_hub_download("light-curve/atcat", "atcat_f32.onnx")
+          hf_hub_download("light-curve/astra-clr", "astra_clr.onnx")
+          EOF
+
+
+  download-hf-models-aarch64:
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Cache HuggingFace models
+        id: hf-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-v1
+          save-always: true
+      - name: Set up Python
+        if: steps.hf-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Download models
+        if: steps.hf-cache.outputs.cache-hit != 'true'
+        run: |
+          pip install huggingface_hub
+          python - <<'EOF'
+          from huggingface_hub import hf_hub_download
+          hf_hub_download("light-curve/astromer1", "astromer1.onnx")
+          hf_hub_download("light-curve/astromer2", "astromer2.onnx")
+          hf_hub_download("light-curve/atcat", "atcat_f32.onnx")
+          hf_hub_download("light-curve/astra-clr", "astra_clr.onnx")
+          EOF
+
+
   test-linux-x86_64:
     runs-on: ubuntu-latest
-    needs: [build-wheel-linux-x86_64]
+    needs: [build-wheel-linux-x86_64, download-hf-models]
 
     strategy:
       fail-fast: false
@@ -144,7 +202,7 @@ jobs:
 
   test-linux-aarch64:
     runs-on: ubuntu-24.04-arm
-    needs: [build-wheel-linux-aarch64]
+    needs: [build-wheel-linux-aarch64, download-hf-models-aarch64]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           shared-key: "${{ runner.os }}-${{ runner.arch }}_stable-rust_build-wheels"
           workspaces: "light-curve"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
@@ -89,7 +89,7 @@ jobs:
           shared-key: "${{ runner.os }}-${{ runner.arch }}_stable-rust_build-wheels"
           workspaces: "light-curve"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
@@ -127,7 +127,7 @@ jobs:
         with:
           python-version: "3.${{ matrix.python_minor }}"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Cache HuggingFace models
         uses: actions/cache@v5
         with:
@@ -164,7 +164,7 @@ jobs:
         with:
           python-version: "3.${{ matrix.python_minor }}"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Cache HuggingFace models
         uses: actions/cache@v5
         with:
@@ -185,7 +185,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - run: uvx ruff check .
         working-directory: light-curve
 
@@ -249,7 +249,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -288,7 +288,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Cache HuggingFace models
         uses: actions/cache@v5
         with:
@@ -341,7 +341,7 @@ jobs:
           shared-key: "${{ runner.os }}_msrv-rust_maturin-build"
           workspaces: "light-curve"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -366,7 +366,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
v5 runs on Node.js 20 which is being deprecated in GitHub Actions.