### PR TITLE
UV extincted BB scale on a constant T value

### DIFF
--- a/light-curve/light_curve/light_curve_py/features/rainbow/_base.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/_base.py
@@ -8,6 +8,7 @@ from light_curve.light_curve_py.dataclass_field import dataclass_field
 from light_curve.light_curve_py.features._base import BaseMultiBandFeature
 from light_curve.light_curve_py.features.rainbow._bands import Bands
 from light_curve.light_curve_py.features.rainbow._parameters import create_parameters_class
+import light_curve.light_curve_py.features.rainbow.spectral as spct
 from light_curve.light_curve_py.features.rainbow._scaler import MultiBandScaler, Scaler
 from light_curve.light_curve_py.minuit_lsq import LeastSquares
 from light_curve.light_curve_py.minuit_ml import MaximumLikelihood
@@ -50,8 +51,14 @@ class BaseRainbowFit(BaseMultiBandFeature):
 
     @staticmethod
     @abstractmethod
-    def _common_parameter_names() -> List[str]:
-        """Common parameter names."""
+    def _common_bol_temp_parameter_names() -> List[str]:
+        """Common parameter names beween bolometric and temperature models."""
+        return NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def _common_temp_spec_parameter_names() -> List[str]:
+        """Common parameter names beween temperature and spectral models."""
         return NotImplementedError
 
     @staticmethod
@@ -81,7 +88,8 @@ class BaseRainbowFit(BaseMultiBandFeature):
 
         self.p = create_parameters_class(
             f"{self.__class__.__name__}Parameters",
-            common=self._common_parameter_names(),
+            common_bol_temp=self._common_bol_temp_parameter_names(),
+            common_temp_spec=self._common_temp_spec_parameter_names(),
             bol=self._bolometric_parameter_names(),
             temp=self._temperature_parameter_names(),
             spec=self._spectral_parameter_names(),
@@ -225,9 +233,9 @@ class BaseRainbowFit(BaseMultiBandFeature):
         # norm = self.planck_nu(speed_of_light / peak_nu, temp) # Peak = 1 normalization
 
         spectral = self.spectral_func(wave_cm, temp, params)
-        planck = spectral / norm
 
-        flux = planck * bol
+        SED = spectral / norm
+        flux = SED * bol
 
         return flux
 
@@ -340,6 +348,10 @@ class BaseRainbowFit(BaseMultiBandFeature):
             initial_guesses = self._initial_guesses(t, m, sigma, band)
             limits = self._limits(t, m, sigma, band)
 
+        # Force all parameter dictionaries to follow enum / Minuit order
+        initial_guesses = {name: initial_guesses[name] for name in self.names}
+        limits = {name: limits[name] for name in self.names}
+
         # least_squares = LeastSquares(
         cost_function = MaximumLikelihood(
             model=self._lsq_model,
@@ -350,6 +362,7 @@ class BaseRainbowFit(BaseMultiBandFeature):
             upper_mask=upper_mask,
         )
         minuit = self.Minuit(cost_function, name=self.names, **initial_guesses)
+        
         # TODO: expose these parameters through function arguments
         if print_level is not None:
             minuit.print_level = print_level
@@ -368,7 +381,7 @@ class BaseRainbowFit(BaseMultiBandFeature):
                 # That's what iterate is supposed to do?..
                 minuit.simplex()
                 # FIXME: it may drive the fit valid, but we will not have Hesse run on last iteration
-
+        
         if debug:
             # Expose everything we have to outside, unscaled, for easier debugging
             self.minuit = minuit

--- a/light-curve/light_curve/light_curve_py/features/rainbow/_base.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/_base.py
@@ -8,7 +8,6 @@ from light_curve.light_curve_py.dataclass_field import dataclass_field
 from light_curve.light_curve_py.features._base import BaseMultiBandFeature
 from light_curve.light_curve_py.features.rainbow._bands import Bands
 from light_curve.light_curve_py.features.rainbow._parameters import create_parameters_class
-import light_curve.light_curve_py.features.rainbow.spectral as spct
 from light_curve.light_curve_py.features.rainbow._scaler import MultiBandScaler, Scaler
 from light_curve.light_curve_py.minuit_lsq import LeastSquares
 from light_curve.light_curve_py.minuit_ml import MaximumLikelihood
@@ -362,7 +361,7 @@ class BaseRainbowFit(BaseMultiBandFeature):
             upper_mask=upper_mask,
         )
         minuit = self.Minuit(cost_function, name=self.names, **initial_guesses)
-        
+
         # TODO: expose these parameters through function arguments
         if print_level is not None:
             minuit.print_level = print_level
@@ -381,7 +380,7 @@ class BaseRainbowFit(BaseMultiBandFeature):
                 # That's what iterate is supposed to do?..
                 minuit.simplex()
                 # FIXME: it may drive the fit valid, but we will not have Hesse run on last iteration
-        
+
         if debug:
             # Expose everything we have to outside, unscaled, for easier debugging
             self.minuit = minuit

--- a/light-curve/light_curve/light_curve_py/features/rainbow/_parameters.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/_parameters.py
@@ -26,7 +26,8 @@ def create_int_enum(cls_name: str, attributes: Iterable[str]):
 def create_parameters_class(
     cls_name: str,
     *,
-    common: List[str],
+    common_bol_temp: List[str],
+    common_temp_spec: List[str],
     bol: List[str],
     temp: List[str],
     spec: List[str],
@@ -39,8 +40,10 @@ def create_parameters_class(
     ----------
     cls_name : str
         Name of the class to create.
-    common : list of str
-        Common parameters for both bolometric and temperature models.
+    common_bol_temp : list of str
+        Common parameters for the bolometric and temperature models.
+    common_temp_spec : list of str
+        Common parameters for the spectral and temperature models.
     bol : list of str
         Bolometric model parameters, without common parameters.
     temp : list of str
@@ -53,29 +56,32 @@ def create_parameters_class(
     with_baseline : bool
         Whether to include baseline parameters, one per band in `bands`.
     """
-    attributes = common + bol + temp + spec
+    attributes = common_bol_temp + common_temp_spec + bol + temp + spec
     if with_baseline:
         baseline = list(map(baseline_parameter_name, bands.names))
         attributes += baseline
 
     enum = create_int_enum(cls_name, attributes)
 
-    enum.all_common = common
-    enum.common_idx = np.array([enum[attr] for attr in common])
+    enum.all_common_bol_temp = common_bol_temp
+    enum.common_bol_temp_idx = np.array([enum[attr] for attr in common_bol_temp])
+
+    enum.all_common_temp_spec = common_temp_spec
+    enum.common_temp_spec_idx = np.array([enum[attr] for attr in common_temp_spec])
 
     enum.bol = bol
     enum.bol_idx = np.array([enum[attr] for attr in enum.bol], dtype=np.int64)
-    enum.all_bol = common + bol
+    enum.all_bol = common_bol_temp + bol
     enum.all_bol_idx = np.array([enum[attr] for attr in enum.all_bol], dtype=np.int64)
 
     enum.temp = temp
     enum.temp_idx = np.array([enum[attr] for attr in enum.temp], dtype=np.int64)
-    enum.all_temp = common + temp
+    enum.all_temp = common_bol_temp + common_temp_spec + temp
     enum.all_temp_idx = np.array([enum[attr] for attr in enum.all_temp], dtype=np.int64)
 
     enum.spec = spec
     enum.spec_idx = np.array([enum[attr] for attr in enum.spec], dtype=np.int64)
-    enum.all_spec = spec
+    enum.all_spec = common_temp_spec + spec
     enum.all_spec_idx = np.array([enum[attr] for attr in enum.all_spec], dtype=np.int64)
 
     enum.with_baseline = with_baseline

--- a/light-curve/light_curve/light_curve_py/features/rainbow/generic.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/generic.py
@@ -74,13 +74,13 @@ class RainbowFit(BaseRainbowFit):
     def __post_init__(self):
         if not isinstance(self.bolometric, BaseBolometricTerm):
             self.bolometric = bolometric_terms[self.bolometric]
-    
+
         if not isinstance(self.temperature, BaseTemperatureTerm):
             temperature_name = self.temperature
             self.temperature = temperature_terms[temperature_name]
         else:
             temperature_name = None
-    
+
         if not isinstance(self.spectral, BaseSpectralTerm):
             if self.spectral == "blanketed":
                 if temperature_name == "constant":
@@ -94,7 +94,7 @@ class RainbowFit(BaseRainbowFit):
                     )
             else:
                 self.spectral = spectral_terms[self.spectral]
-    
+
         super().__post_init__()
 
     def _common_bol_temp_parameter_names(self) -> List[str]:
@@ -120,7 +120,7 @@ class RainbowFit(BaseRainbowFit):
 
     def _spectral_parameter_names(self) -> List[str]:
         spectral_parameters = self.spectral.parameter_names()
-        return [i for i in spectral_parameters if i not in self._common_temp_spec_parameter_names()] 
+        return [i for i in spectral_parameters if i not in self._common_temp_spec_parameter_names()]
 
     def bol_func(self, t, params):
         return self.bolometric.value(t, *params[self.p.all_bol_idx])

--- a/light-curve/light_curve/light_curve_py/features/rainbow/generic.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/generic.py
@@ -39,15 +39,8 @@ class RainbowFit(BaseRainbowFit):
         Other options are: 'constant', 'delayed_sigmoid'
     spectral : str or BaseSpectralTerm subclass, optional
         The spectral SED model. Default is 'planck' (standard blackbody,
-        no extra fit parameters). Use 'blanketed' for a UV-extincted blackbody:
-
-        .. math::
-            F(\\lambda) = B_\\nu(T) \\cdot e^{-\\tau},\\quad
-            \\tau = 10^{\\texttt{log\\_intensity}} \\cdot e^{-\\lambda/\\texttt{lambda\\_scale}}
-
-        This adds two fit parameters: ``log_intensity`` (blanketing strength,
-        range 1.5–6) and ``lambda_scale`` (characteristic blanketing wavelength
-        in Å, range 100–2000).
+        no extra fit parameters). Use 'blanketed' for a UV-extincted blackbody.
+        It adds one parameter to fit: ``lambda_scale`` (blanketing strength from ~0 to 1)
 
     Methods
     -------
@@ -75,39 +68,59 @@ class RainbowFit(BaseRainbowFit):
     temperature: Union[str, BaseTemperatureTerm] = dataclass_field(default="sigmoid", kw_only=True)
     """Which parametric temperature term to use"""
 
-    spectral: Union[str, BaseSpectralTerm] = dataclass_field(
-        default="planck",
-        kw_only=True,
-    )
+    spectral: Union[str, BaseSpectralTerm] = dataclass_field(default="planck", kw_only=True)
     """Which spectral term to use"""
 
     def __post_init__(self):
         if not isinstance(self.bolometric, BaseBolometricTerm):
             self.bolometric = bolometric_terms[self.bolometric]
-
+    
         if not isinstance(self.temperature, BaseTemperatureTerm):
-            self.temperature = temperature_terms[self.temperature]
-
+            temperature_name = self.temperature
+            self.temperature = temperature_terms[temperature_name]
+        else:
+            temperature_name = None
+    
         if not isinstance(self.spectral, BaseSpectralTerm):
-            self.spectral = spectral_terms[self.spectral]
-
+            if self.spectral == "blanketed":
+                if temperature_name == "constant":
+                    self.spectral = spectral_terms["blanketed_constant_temperature"]
+                elif temperature_name == "sigmoid":
+                    self.spectral = spectral_terms["blanketed_sigmoid_temperature"]
+                else:
+                    raise ValueError(
+                        "`spectral='blanketed'` is only supported with "
+                        "`temperature='constant'` or `temperature='sigmoid'`."
+                    )
+            else:
+                self.spectral = spectral_terms[self.spectral]
+    
         super().__post_init__()
 
-    def _common_parameter_names(self) -> List[str]:
+    def _common_bol_temp_parameter_names(self) -> List[str]:
         bolometric_parameters = self.bolometric.parameter_names()
         temperature_parameters = self.temperature.parameter_names()
-        return [j for j in bolometric_parameters if j in temperature_parameters]
+        common_bol_temp = [j for j in bolometric_parameters if j in temperature_parameters]
+        return common_bol_temp
+
+    def _common_temp_spec_parameter_names(self) -> List[str]:
+        spectral_parameters = self.spectral.parameter_names()
+        temperature_parameters = self.temperature.parameter_names()
+        common_temp_spec = [j for j in temperature_parameters if j in spectral_parameters]
+        return common_temp_spec
 
     def _bolometric_parameter_names(self) -> List[str]:
         bolometric_parameters = self.bolometric.parameter_names()
-        return [i for i in bolometric_parameters if i not in self._common_parameter_names()]
+        return [i for i in bolometric_parameters if i not in self._common_bol_temp_parameter_names()]
 
     def _temperature_parameter_names(self) -> List[str]:
         temperature_parameters = self.temperature.parameter_names()
-        return [i for i in temperature_parameters if i not in self._common_parameter_names()]
+        common = self._common_bol_temp_parameter_names() + self._common_temp_spec_parameter_names()
+        return [i for i in temperature_parameters if i not in common]
 
     def _spectral_parameter_names(self) -> List[str]:
-        return self.spectral.parameter_names()
+        spectral_parameters = self.spectral.parameter_names()
+        return [i for i in spectral_parameters if i not in self._common_temp_spec_parameter_names()] 
 
     def bol_func(self, t, params):
         return self.bolometric.value(t, *params[self.p.all_bol_idx])

--- a/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List, Union\
+from typing import Dict, List, Union
 
 import numpy as np
 
@@ -16,7 +16,7 @@ __all__ = [
 planck_constant = 6.62607004e-27  # erg s
 speed_of_light = 2.99792458e10  # cm/s
 boltzman_constant = 1.380649e-16  # erg/K
-b_wien = 28977720 # Angstrom*K
+b_wien = 28977720  # Angstrom*K
 
 
 @dataclass()
@@ -97,7 +97,7 @@ class BlanketedPlanckConstTemp(BaseSpectralTerm):
         # Phenomenological value for the slope of the extinction
         # Fitting instead of fixing is likely overkill for broad band photometry
         intensity = 100
-        
+
         # Encodes how far (in wavelength) the maximum UV extinction extends (at lambda_scale=1).
         # Allows the extinction to affect the BB wavelength past the peak (in the formula below).
         max_extinction = 2 * b_wien
@@ -127,6 +127,7 @@ class BlanketedPlanckConstTemp(BaseSpectralTerm):
             "lambda_scale": (0.001, 1.0),
         }
 
+
 @dataclass()
 class BlanketedPlanckSigmoidTemp(BaseSpectralTerm):
     """Blackbody spectrum with exponential blanketing."""
@@ -146,7 +147,7 @@ class BlanketedPlanckSigmoidTemp(BaseSpectralTerm):
         # Phenomenological value for the slope of the extinction
         # Fitting instead of fixing is likely overkill for broad band photometry
         intensity = 100
-        
+
         # Encodes how far (in wavelength) the maximum UV extinction extends (at lambda_scale=1).
         # Allows the extinction to affect the BB wavelength past the peak (in the formula below).
         max_extinction = 2 * b_wien
@@ -179,9 +180,8 @@ class BlanketedPlanckSigmoidTemp(BaseSpectralTerm):
         }
 
 
-
 spectral_terms = {
     "planck": PlanckSpectralTerm,
     "blanketed_constant_temperature": BlanketedPlanckConstTemp,
-    "blanketed_sigmoid_temperature": BlanketedPlanckSigmoidTemp
+    "blanketed_sigmoid_temperature": BlanketedPlanckSigmoidTemp,
 }

--- a/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
+++ b/light-curve/light_curve/light_curve_py/features/rainbow/spectral.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List, Union
+from typing import Dict, List, Union\
 
 import numpy as np
 
@@ -8,13 +8,15 @@ __all__ = [
     "spectral_terms",
     "BaseSpectralTerm",
     "PlanckSpectralTerm",
-    "BlanketedPlanckSpectralTerm",
+    "BlanketedPlanckConstTemp",
+    "BlanketedPlanckSigmoidTemp",
 ]
 
 # CODATA 2018
 planck_constant = 6.62607004e-27  # erg s
 speed_of_light = 2.99792458e10  # cm/s
 boltzman_constant = 1.380649e-16  # erg/K
+b_wien = 28977720 # Angstrom*K
 
 
 @dataclass()
@@ -77,7 +79,7 @@ class PlanckSpectralTerm(BaseSpectralTerm):
 
 
 @dataclass()
-class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
+class BlanketedPlanckConstTemp(BaseSpectralTerm):
     """Blackbody spectrum with exponential blanketing"""
 
     @staticmethod
@@ -93,19 +95,17 @@ class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
         base = PlanckSpectralTerm.value(wave_cm, T)
 
         # Phenomenological value for the slope of the extinction
-        # No physical reasons for this value, just nice fits
         # Fitting instead of fixing is likely overkill for broad band photometry
-        intensity = 10**2
-
-        # This empirical constant encodes how far (in wavelength) the maximum UV extinction extends (lambda_scale=1).
-        # The scale of this value comes from how it relates temperature to wavelength in angstrom.
-        # This value allows the extinction to affect the BB wavelength a little over the peak (in the formula below).
-        max_extinction = 5e7
+        intensity = 100
+        
+        # Encodes how far (in wavelength) the maximum UV extinction extends (at lambda_scale=1).
+        # Allows the extinction to affect the BB wavelength past the peak (in the formula below).
+        max_extinction = 2 * b_wien
 
         # Lambda_angstrom represents how far (in absolute wavelength) the extinction affects the BB.
         # Lambda_scale quantifies this between 0 (no UV ext) and 1 max suppression (encoded by max_extinction above)
         # We want this maximum extinction to scale with the size of the BB.
-        # Therefore, lambda_angstrom should inversely scale with temperature.
+        # We use T to give the correct order of magntiude of the scaling
         lambda_angstrom = max_extinction * lambda_scale / T
 
         # Convert to cm to match wave_cm
@@ -127,8 +127,61 @@ class BlanketedPlanckSpectralTerm(BaseSpectralTerm):
             "lambda_scale": (0.001, 1.0),
         }
 
+@dataclass()
+class BlanketedPlanckSigmoidTemp(BaseSpectralTerm):
+    """Blackbody spectrum with exponential blanketing."""
+
+    @staticmethod
+    def parameter_names():
+        return ["Tmin", "Tmax", "lambda_scale"]
+
+    @staticmethod
+    def parameter_scalings():
+        return [None, None, None]
+
+    @staticmethod
+    def value(wave_cm, T, Tmin, Tmax, lambda_scale):
+        base = PlanckSpectralTerm.value(wave_cm, T)
+
+        # Phenomenological value for the slope of the extinction
+        # Fitting instead of fixing is likely overkill for broad band photometry
+        intensity = 100
+        
+        # Encodes how far (in wavelength) the maximum UV extinction extends (at lambda_scale=1).
+        # Allows the extinction to affect the BB wavelength past the peak (in the formula below).
+        max_extinction = 2 * b_wien
+
+        # The depth of exinction depends on the temperature of source.
+        # But it should not vary as the object cools down. We use T(t=~peak)
+        T_scale = (Tmin + Tmax) / 2
+
+        # Lambda_angstrom represents how far (in absolute wavelength) the extinction affects the BB.
+        # Lambda_scale quantifies this between 0 (no UV ext) and 1 max suppression (encoded by max_extinction above)
+        lambda_angstrom = max_extinction * lambda_scale / T_scale
+
+        # Convert to cm to match wave_cm
+        lambda_cm = lambda_angstrom * 1e-8
+
+        tau = intensity * np.exp(-wave_cm / lambda_cm)
+
+        return base * np.exp(-tau)
+
+    @staticmethod
+    def initial_guesses(t, m, sigma, band):
+        return {
+            "lambda_scale": 0.001,
+        }
+
+    @staticmethod
+    def limits(t, m, sigma, band):
+        return {
+            "lambda_scale": (0.001, 1.0),
+        }
+
+
 
 spectral_terms = {
     "planck": PlanckSpectralTerm,
-    "blanketed": BlanketedPlanckSpectralTerm,
+    "blanketed_constant_temperature": BlanketedPlanckConstTemp,
+    "blanketed_sigmoid_temperature": BlanketedPlanckSigmoidTemp
 }


### PR DESCRIPTION
UV extinction depth used to scale on T(t), which is unphysical as the temperature evolves. Instead now, it scales on a fix temperature: either T=cste if the option is selected, or T=(Tmax+Tmin)/2 if sigmoid temperature is selected.

The latter necessitated to expand the common parameter list, so that the spectral model can access the Tmin and Tmax, without adding any extra fitted parameters.
