### PR TITLE
ci(docs): fix mike reusing source-code branch instead of fetching docs remote

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,6 +78,11 @@ jobs:
         if: github.ref_type == 'branch'
         run: |
           source .venv/bin/activate
+          # Detach HEAD and drop the local branch so mike fetches docs-site/${DOCS_BRANCH}
+          # fresh instead of reusing the source-code branch of the same name.
+          git fetch docs-site "${DOCS_BRANCH}"
+          git checkout --detach HEAD
+          git branch -D "${DOCS_BRANCH}"
           mike deploy --push --remote docs-site --branch "${DOCS_BRANCH}" \
             --update-aliases dev
           mike list --remote docs-site --branch "${DOCS_BRANCH}" | grep -q "latest" \
@@ -87,6 +92,9 @@ jobs:
         if: github.ref_type == 'tag'
         run: |
           source .venv/bin/activate
+          git fetch docs-site "${DOCS_BRANCH}"
+          git checkout --detach HEAD
+          git branch -D "${DOCS_BRANCH}"
           mike deploy --push --remote docs-site --branch "${DOCS_BRANCH}" \
             --update-aliases latest
           mike set-default --push --remote docs-site --branch "${DOCS_BRANCH}" latest


### PR DESCRIPTION
## Summary

- `mike deploy --push --remote docs-site --branch main` finds a local branch named `main` (the source-code checkout) and uses it as the deployment base instead of fetching `docs-site/main`
- The first deploy succeeds because pushing to an empty remote works regardless of history
- Every subsequent deploy fails with `! [rejected] main -> main (fetch first)` because the docs repo has content that the source-code `main` lineage doesn't include
- Fix: fetch `docs-site/${DOCS_BRANCH}`, detach HEAD, and delete the local branch before running mike so it creates a fresh tracking branch from the actual docs content

## Root cause analysis

Run [26956047986](https://github.com/light-curve/light-curve-python/actions/runs/26956047986) (06:25) was the first successful deploy — the docs repo was empty so pushing any history succeeded. Run [26956347611](https://github.com/light-curve/light-curve-python/actions/runs/26956347611) (13:56) then failed 7 hours later with no intervening commits to the docs repo, because mike was building on the source-code `main` branch rather than the docs `main` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)