### PR TITLE
ci(docs): restore docs workflow regressed by multiband merge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,15 +11,19 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
+
+env:
+  DOCS_REPO: light-curve/light-curve.snad.space
+  DOCS_BRANCH: main
 
 jobs:
   docs-deploy:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    # Queue deploys; never cancel — concurrent gh-pages pushes would corrupt the branch
+    # Queue deploys; never cancel — concurrent pushes would corrupt the docs branch
     concurrency:
-      group: gh-pages
+      group: docs-deploy
       cancel-in-progress: false
     runs-on: ubuntu-latest
     defaults:
@@ -30,6 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:
@@ -47,10 +52,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgsl-dev
 
-      - name: Configure git
+      - name: Configure git and docs remote
+        env:
+          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote add docs-site \
+            "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/${DOCS_REPO}.git"
 
       - name: Cache HuggingFace models
         uses: actions/cache@v5
@@ -95,11 +104,12 @@ jobs:
         # pre-commit-ci[bot]).  Run this after every deploy to catch leftovers.
         env:
           GH_TOKEN: ${{ github.token }}
+          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
         run: |
-          git clone --depth=1 --branch=gh-pages \
-            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
-            /tmp/gh-pages-stale
-          cd /tmp/gh-pages-stale
+          git clone --depth=1 --branch="${DOCS_BRANCH}" \
+            "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/${DOCS_REPO}.git" \
+            /tmp/docs-stale
+          cd /tmp/docs-stale
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -132,8 +142,16 @@ jobs:
           subprocess.run(['git', 'add', 'versions.json'], check=True)
           PYEOF
 
-          git diff --cached --quiet && echo "Nothing to commit." || \
-            git commit -m "docs: remove stale PR previews" && git push
+          if git diff --cached --quiet; then
+            echo "Nothing to commit."
+          else
+            git commit -m "docs: remove stale PR previews"
+            for i in 1 2 3; do
+              git push && break
+              git pull --rebase origin "${DOCS_BRANCH}"
+            done
+          fi
+
 
   docs-preview:
     # pull_request_target gives write access even for fork PRs.
@@ -154,11 +172,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
 
       - uses: actions/checkout@v6
         with:
-          ref: gh-pages
-          path: gh-pages-deploy
+          repository: ${{ env.DOCS_REPO }}
+          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          ref: ${{ env.DOCS_BRANCH }}
+          path: docs-deploy
           fetch-depth: 1
 
       - uses: actions/setup-python@v6
@@ -200,34 +221,39 @@ jobs:
           source .venv/bin/activate
           mkdocs build --site-dir /tmp/pr-site
 
-      - name: Push preview to gh-pages
+      - name: Push preview to docs repo
         env:
           PR: ${{ github.event.pull_request.number }}
         run: |
-          rm -rf gh-pages-deploy/pr${PR}
-          cp -r /tmp/pr-site gh-pages-deploy/pr${PR}
-          rm -f gh-pages-deploy/pr${PR}/CNAME
+          rm -rf docs-deploy/pr${PR}
+          cp -r /tmp/pr-site docs-deploy/pr${PR}
+          rm -f docs-deploy/pr${PR}/CNAME
 
           python3 -c "
           import json, os, re
           pr = int(os.environ['PR'])
           entry = {'version': f'pr{pr}', 'title': f'pr{pr}', 'aliases': []}
-          with open('gh-pages-deploy/versions.json') as f:
+          with open('docs-deploy/versions.json') as f:
               versions = json.load(f)
           versions = [v for v in versions if v['version'] != entry['version']]
           non_pr = [v for v in versions if not re.fullmatch(r'pr\d+', v['version'])]
           prs    = [v for v in versions if     re.fullmatch(r'pr\d+', v['version'])]
           prs.append(entry)
           prs.sort(key=lambda v: int(v['version'][2:]))
-          with open('gh-pages-deploy/versions.json', 'w') as f:
+          with open('docs-deploy/versions.json', 'w') as f:
               json.dump(non_pr + prs, f, indent=2)
               f.write('\n')
           "
 
-          cd gh-pages-deploy
+          cd docs-deploy
           git add pr${PR} versions.json
-          git diff --cached --quiet && echo "No changes" || git commit -m "docs: update PR #${PR} preview"
-          git push
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "docs: update PR #${PR} preview"
+          # Retry push with rebase in case of concurrent preview builds
+          for i in 1 2 3; do
+            git push && break
+            git pull --rebase origin "${DOCS_BRANCH}"
+          done
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v9


### PR DESCRIPTION
## Summary

- The multiband branch (PR #762) was created before the docs-to-separate-repo migration (PR #760) and wasn't rebased. Its squash commit included a stale `docs.yml` that overwrote the migration without producing a merge conflict.
- The `docs-preview` CI job was broken because it tried to checkout a `gh-pages` branch that no longer exists in this repo (docs moved to `light-curve/light-curve.snad.space`).
- Restores `docs.yml` to the state at `62aacabc` (last correct commit before the regression).

**What was regressed and is now fixed:**
- `env:` block with `DOCS_REPO` / `DOCS_BRANCH` removed → restored
- `persist-credentials: false` on source checkout removed → restored
- `Configure git and docs remote` step (adds `docs-site` remote with `DOCS_DEPLOY_TOKEN`) removed → restored
- Stale-preview cleanup was cloning `gh-pages` from this repo → restored to clone `${DOCS_BRANCH}` from `${DOCS_REPO}`
- `docs-preview` job was checking out `ref: gh-pages` from this repo → restored to checkout `DOCS_REPO` via `DOCS_DEPLOY_TOKEN`
- Rebase-retry push loops in stale cleanup and preview push removed → restored
- `permissions.contents` changed from `read` to `write` unnecessarily → restored to `read`

## Test plan

- [ ] Verify `docs-preview` CI passes on this PR
- [ ] After merge, verify `docs-deploy` CI passes on push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)