### PR TITLE
Cache HuggingFace model downloads and add HF_TOKEN to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Deploy dev (main branch)
         if: github.ref_type == 'branch'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           source .venv/bin/activate
           # Detach HEAD and drop the local branch so mike fetches docs-site/${DOCS_BRANCH}
@@ -90,6 +92,8 @@ jobs:
 
       - name: Deploy release (tag)
         if: github.ref_type == 'tag'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           source .venv/bin/activate
           git fetch docs-site "${DOCS_BRANCH}"
@@ -217,6 +221,8 @@ jobs:
           cd light-curve && maturin develop --extras=full --group=docs -q
 
       - name: Build docs
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           source .venv/bin/activate
           mkdocs build --site-dir /tmp/pr-site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,6 +126,7 @@ jobs:
           package-dir: ./light-curve
         env:
           CIBW_BUILD_VERBOSITY: "3"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,8 @@ jobs:
           name: ${{ matrix.wheel_artifact }}
           path: light-curve/wheels/
       - name: Run tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: uvx --with tox-uv tox -e py3${{ matrix.python_minor }}-test --installpkg=$(ls wheels/*.whl)
 
 
@@ -176,6 +178,8 @@ jobs:
           name: wheels-linux-aarch64
           path: light-curve/wheels/
       - name: Run tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: uvx --with tox-uv tox -e py3${{ matrix.python_minor }}-test --installpkg=$(ls wheels/*.whl)
 
 
@@ -260,6 +264,8 @@ jobs:
           path: ~/.cache/huggingface
           key: huggingface-v1
       - name: Generate code coverage
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           uv venv .venv
@@ -301,6 +307,8 @@ jobs:
           path: wheels/
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation
@@ -379,4 +387,6 @@ jobs:
           key: huggingface-v1
       - name: Run slow tests
         working-directory: light-curve
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: uvx --with tox-uv tox -e py314-slow --installpkg=$(ls wheels/*.whl)

--- a/light-curve/light_curve/embed/model.py
+++ b/light-curve/light_curve/embed/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import Counter
 from enum import IntEnum
+from functools import lru_cache
 from typing import TYPE_CHECKING, Mapping, Sequence
 
 import numpy as np
@@ -102,22 +103,7 @@ class EmbeddingSession(ABC):
         ImportError
             If no ``onnxruntime`` variant is installed.
         """
-        try:
-            from huggingface_hub import hf_hub_download
-        except ImportError as exc:
-            hf_url = f"https://huggingface.co/{cls.hf_repo}/resolve/main/{filename}"
-            raise ImportError(
-                "huggingface_hub is required to download models from HuggingFace.\n"
-                "Install it with:\n"
-                "  pip install huggingface-hub\n"
-                "Or download the model file directly:\n"
-                f"  {hf_url}\n"
-                "then load it with:\n"
-                "  import onnxruntime as ort\n"
-                f'  {cls.__name__}(session=ort.InferenceSession("/path/to/{filename}")")'
-            ) from exc
-
-        model_path = hf_hub_download(repo_id=cls.hf_repo, filename=filename)
+        model_path = _hf_hub_download_cached(cls.hf_repo, filename)
 
         if ort_session_kwargs is None:
             ort_session_kwargs = {}
@@ -419,6 +405,25 @@ class ImplicitMultiBandModel(MultiBandModel, ABC):
     @abstractmethod
     def preprocess_single_band(self, *arrays: ArrayLike, band_idx: int, seq_size: int) -> InputTensors:
         raise NotImplementedError
+
+
+@lru_cache
+def _hf_hub_download_cached(repo_id: str, filename: str) -> str:
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:
+        hf_url = f"https://huggingface.co/{repo_id}/resolve/main/{filename}"
+        raise ImportError(
+            "huggingface_hub is required to download models from HuggingFace.\n"
+            "Install it with:\n"
+            "  pip install huggingface-hub\n"
+            "Or download the model file directly:\n"
+            f"  {hf_url}\n"
+            "then load it with:\n"
+            "  import onnxruntime as ort\n"
+            f'  session=ort.InferenceSession("/path/to/{filename}")'
+        ) from exc
+    return hf_hub_download(repo_id=repo_id, filename=filename)
 
 
 _ONNX_INSTALL_HINT = (

--- a/light-curve/pyproject.toml
+++ b/light-curve/pyproject.toml
@@ -283,3 +283,4 @@ environment = { "PATH" = "$PATH:$HOME/.cargo/bin", "MATURIN_PEP517_ARGS" = "--lo
 select = "cp*-macosx_arm64"
 test-command = "pytest {package}/README.md {package}/light_curve/ {package}/tests/"
 test-groups = ["test"]
+environment-pass = ["HF_TOKEN"]


### PR DESCRIPTION
## Description

This PR improves the handling of HuggingFace model downloads by:

1. **Extracting download logic to a cached function**: Moved the HuggingFace hub download logic from the `from_hf()` class method into a standalone `_hf_hub_download_cached()` function decorated with `@lru_cache`. This avoids redundant downloads when the same model is loaded multiple times in a single process.

2. **Adding HF_TOKEN to CI workflows**: Updated all GitHub Actions workflows (`test.yml`, `docs.yml`, `publish.yml`) to pass the `HF_TOKEN` secret to test and build environments. This enables authenticated access to HuggingFace Hub, which is necessary for:
   - Running tests that download models
   - Building documentation that may reference models
   - Publishing wheels with model integration tests

3. **Configuring cibuildwheel to pass HF_TOKEN**: Added `environment-pass = ["HF_TOKEN"]` to `pyproject.toml` under the `[tool.cibuildwheel]` section so the token is available during wheel builds.

The refactoring maintains the same error handling and user-friendly error messages while improving efficiency and enabling authenticated CI workflows.

https://claude.ai/code/session_018NenUYYkyAYABRukrAKKLH