### PR TITLE
ci: add prepare-hf-models gate job to eliminate HF rate limits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,12 +61,6 @@ jobs:
           git remote add docs-site \
             "https://x-access-token:${DOCS_DEPLOY_TOKEN}@github.com/${DOCS_REPO}.git"
 
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/huggingface
-          key: huggingface-v1
-
       - name: Install from source with docs dependencies
         run: |
           python -m venv .venv
@@ -206,12 +200,6 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/huggingface
-          key: huggingface-v1
 
       - name: Install from source with docs dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,13 +99,6 @@ jobs:
           CIBW_ARCHS=$(echo ${{ matrix.cibw_build }} | cut -d'_' -f2,3)
           echo "CIBW_ARCHS=${CIBW_ARCHS}" >> $GITHUB_ENV
 
-      - name: Cache HuggingFace models
-        if: matrix.os == 'macos-14'
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/huggingface
-          key: huggingface-v1
-
       - name: Cache vcpkg binary packages for Windows
         if: ${{ runner.os == 'Windows' }}
         uses: actions/cache@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,8 +138,7 @@ jobs:
         run: |
           uv venv .venv
           source .venv/bin/activate
-          uv pip install wheels/*.whl
-          uv pip install --group test
+          uv pip install wheels/*.whl --group test
           pytest tests/embed/
       - name: Save HuggingFace cache
         uses: actions/cache/save@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           path: ~/.cache/huggingface
           key: huggingface-v1
+          save-always: true
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,8 +121,8 @@ jobs:
           python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
+      - name: Restore HuggingFace cache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/huggingface
           key: huggingface-v1-${{ github.run_id }}
@@ -141,6 +141,11 @@ jobs:
           uv pip install wheels/*.whl
           uv pip install --group test
           pytest tests/embed/
+      - name: Save HuggingFace cache
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-v1-${{ github.run_id }}
 
 
   test-linux-x86_64:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,9 +103,48 @@ jobs:
           path: light-curve/target/wheels/
 
 
+  prepare-hf-models:
+    runs-on: ubuntu-24.04-arm
+    needs: [build-wheel-linux-aarch64]
+
+    defaults:
+      run:
+        working-directory: light-curve
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Cache HuggingFace models
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-v1
+      - name: Download wheels
+        uses: actions/download-artifact@v8
+        with:
+          name: wheels-linux-aarch64
+          path: light-curve/wheels/
+      - name: Run embed tests (populates HF cache)
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install wheels/*.whl
+          uv pip install --group test
+          pytest tests/embed/
+
+
   test-linux-x86_64:
     runs-on: ubuntu-latest
-    needs: [build-wheel-linux-x86_64]
+    needs: [build-wheel-linux-x86_64, prepare-hf-models]
 
     strategy:
       fail-fast: false
@@ -129,10 +168,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Cache HuggingFace models
+        id: hf-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
           key: huggingface-v1
+      - name: Set HF offline mode
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
@@ -146,7 +189,7 @@ jobs:
 
   test-linux-aarch64:
     runs-on: ubuntu-24.04-arm
-    needs: [build-wheel-linux-aarch64]
+    needs: [build-wheel-linux-aarch64, prepare-hf-models]
 
     strategy:
       fail-fast: false
@@ -168,10 +211,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Cache HuggingFace models
+        id: hf-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
           key: huggingface-v1
+      - name: Set HF offline mode
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
@@ -230,6 +277,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    needs: [prepare-hf-models]
 
     defaults:
       run:
@@ -259,10 +307,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgsl-dev
       - name: Cache HuggingFace models
+        id: hf-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
           key: huggingface-v1
+      - name: Set HF offline mode
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
       - name: Generate code coverage
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -285,7 +337,7 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-latest
-    needs: [build-wheel-linux-x86_64]
+    needs: [build-wheel-linux-x86_64, prepare-hf-models]
 
     steps:
       - uses: actions/checkout@v6
@@ -296,10 +348,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Cache HuggingFace models
+        id: hf-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
           key: huggingface-v1
+      - name: Set HF offline mode
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
@@ -362,7 +418,7 @@ jobs:
 
   slow-tests:
     runs-on: ubuntu-latest
-    needs: [build-wheel-linux-x86_64]
+    needs: [build-wheel-linux-x86_64, prepare-hf-models]
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -381,10 +437,14 @@ jobs:
           name: wheels-linux-x86_64
           path: light-curve/wheels/
       - name: Cache HuggingFace models
+        id: hf-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
           key: huggingface-v1
+      - name: Set HF offline mode
+        if: steps.hf-cache.outputs.cache-hit == 'true'
+        run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
       - name: Run slow tests
         working-directory: light-curve
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,8 +125,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
-          key: huggingface-v1
-          save-always: true
+          key: huggingface-v1-${{ github.run_id }}
+          restore-keys: huggingface-v1
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
@@ -173,7 +173,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
-          key: huggingface-v1
+          key: huggingface-v1-${{ github.run_id }}
+          restore-keys: huggingface-v1
       - name: Set HF offline mode
         if: steps.hf-cache.outputs.cache-hit == 'true'
         run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
@@ -216,7 +217,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
-          key: huggingface-v1
+          key: huggingface-v1-${{ github.run_id }}
+          restore-keys: huggingface-v1
       - name: Set HF offline mode
         if: steps.hf-cache.outputs.cache-hit == 'true'
         run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
@@ -312,7 +314,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
-          key: huggingface-v1
+          key: huggingface-v1-${{ github.run_id }}
+          restore-keys: huggingface-v1
       - name: Set HF offline mode
         if: steps.hf-cache.outputs.cache-hit == 'true'
         run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
@@ -353,7 +356,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
-          key: huggingface-v1
+          key: huggingface-v1-${{ github.run_id }}
+          restore-keys: huggingface-v1
       - name: Set HF offline mode
         if: steps.hf-cache.outputs.cache-hit == 'true'
         run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV
@@ -442,7 +446,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/huggingface
-          key: huggingface-v1
+          key: huggingface-v1-${{ github.run_id }}
+          restore-keys: huggingface-v1
       - name: Set HF offline mode
         if: steps.hf-cache.outputs.cache-hit == 'true'
         run: echo "HF_HUB_OFFLINE=1" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- Adds a `prepare-hf-models` gate job that runs `pytest tests/embed/` on aarch64 to download all HuggingFace models into the Actions cache before any test jobs start
- All HF-using jobs (`test-linux-x86_64`, `test-linux-aarch64`, `coverage`, `benchmarks`, `slow-tests`) now declare `needs: [prepare-hf-models]` and restore the cache; if the cache is warm they set `HF_HUB_OFFLINE=1` to skip even the HEAD check
- Uses `actions/cache/restore` + `actions/cache/save` split with a run-scoped key (`huggingface-v1-${{ github.run_id }}`) to guarantee a fresh, complete cache is written every run (the split is required because the combined `actions/cache` step with `save-always: true` is deprecated and silently skips the save on cache hit)

## Test plan

- [x] CI green on branch `fix-hf-429` (run [27146270981](https://github.com/light-curve/light-curve-python/actions/runs/27146270981)): all jobs pass including `coverage` which was previously failing with `OfflineModeIsEnabled`
- [x] `slow-tests` correctly skipped (only runs on schedule/workflow_dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)