### PR TITLE
CI: fix CodSpeed benchmarks failing on fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,8 +378,13 @@ jobs:
         with:
           name: wheels-linux-x86_64
           path: wheels/
+      - name: Check CodSpeed token
+        if: github.repository == 'light-curve/light-curve-python' && env.CODSPEED_TOKEN == ''
+        run: |
+          echo "::error::CODSPEED_TOKEN secret is missing or expired — please renew it."
+          exit 1
       - name: Run benchmarks
-        if: env.CODSPEED_TOKEN != '' || github.repository == 'light-curve/light-curve-python'
+        if: env.CODSPEED_TOKEN != ''
         uses: CodSpeedHQ/action@v4
         with:
           token: ${{ env.CODSPEED_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes the `benchmarks` job failing with `401 Unauthorized` on fork PRs (e.g. #771)
- Adds an explicit token-presence check that fails loudly when the secret is missing on the main repo, so an expired or deleted `CODSPEED_TOKEN` is caught immediately

## Root cause

The old step condition:
```yaml
if: env.CODSPEED_TOKEN != '' || github.repository == 'light-curve/light-curve-python'
```
always evaluated `true` for PRs targeting this repo, even from forks — because `github.repository` is the *base* repo. GitHub does not expose secrets to fork PRs, so `CODSPEED_TOKEN` was empty and the CodSpeed upload step returned 401.

## Fix

Split into two steps:
1. **Check CodSpeed token** — runs only on the main repo when the token is absent; exits with a clear error annotation so a missing/expired secret is immediately visible.
2. **Run benchmarks** — runs only when the token is actually present (`env.CODSPEED_TOKEN != ''`), silently skipped for fork PRs.

## Test plan

- [ ] Fork PR: `Check CodSpeed token` skipped, `Run benchmarks` skipped — no failure
- [ ] Main repo push with token: `Check CodSpeed token` skipped, `Run benchmarks` runs normally
- [ ] Main repo push without token: `Check CodSpeed token` fails with `::error::CODSPEED_TOKEN secret is missing or expired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)