### PR TITLE
CI: fix branch-delete failure when deploying from a tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -92,7 +92,7 @@ jobs:
           source .venv/bin/activate
           git fetch docs-site "${DOCS_BRANCH}"
           git checkout --detach HEAD
-          git branch -D "${DOCS_BRANCH}"
+          git branch -D "${DOCS_BRANCH}" 2>/dev/null || true
           mike deploy --push --remote docs-site --branch "${DOCS_BRANCH}" \
             --update-aliases latest
           mike set-default --push --remote docs-site --branch "${DOCS_BRANCH}" latest


### PR DESCRIPTION
## Summary

When `publish.yml` triggers the docs deploy via a `v*` tag push, `actions/checkout` leaves the repo in a detached HEAD state with no local branch. The existing `git branch -D main` then fails with `error: branch 'main' not found`, breaking the release docs deploy.

Fix: add `2>/dev/null || true` so the delete is a no-op when there is no local branch to remove (tag deploys) while still working correctly for branch deploys where a local `main` does exist.

Reproducer: push any `v*` tag — the "Deploy release (tag)" step fails at `git branch -D main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)