### PR TITLE
fix(embed): fix ChronosBolt docs table and require explicit size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
---
+- **Experimental feature broken**: `light_curve.embed.ChronosBolt.from_hf()` now requires an
+  explicit `size` argument instead of defaulting to `"base"`. The four sizes have different
+  embedding dimensions, so a silent default was error-prone; callers must now pass e.g.
+  `ChronosBolt.from_hf(size="base")`.
 
 ### Deprecated
 

--- a/light-curve/light_curve/embed/chronos.py
+++ b/light-curve/light_curve/embed/chronos.py
@@ -263,15 +263,7 @@ class ChronosBolt(_ChronosModel):
 
     A faster, patch-based Chronos variant available in four sizes with
     different embedding dimensions (native context up to 2048 observations):
-
-    ===== =========
-    size  embed_dim
-    ===== =========
-    tiny  256
-    mini  384
-    small 512
-    base  768
-    ===== =========
+    ``tiny`` (256), ``mini`` (384), ``small`` (512), and ``base`` (768).
 
     The ONNX models are hosted on HuggingFace at
     ``https://huggingface.co/light-curve/chronos-bolt-<size>``.
@@ -331,7 +323,7 @@ class ChronosBolt(_ChronosModel):
     @classmethod
     def from_hf(
         cls,
-        size: str = "base",
+        size: str,
         output: str = "mean",
         *,
         reduction: str | list[str] | Reduction = "end",
@@ -342,8 +334,9 @@ class ChronosBolt(_ChronosModel):
 
         Parameters
         ----------
-        size : {"tiny", "mini", "small", "base"}, optional
-            Model size to load.  Defaults to ``"base"``.
+        size : {"tiny", "mini", "small", "base"}
+            Model size to load.  Required: the sizes have different embedding
+            dimensions, so there is no meaningful default.
         output : str, optional
             ``"mean"`` (default) or ``"sequence"``.
         reduction : str, list of str, or Reduction, optional


### PR DESCRIPTION
The ChronosBolt docstring used a reStructuredText grid table for the size/embed_dim mapping, but mkdocstrings renders docstrings as Markdown, so it appeared as a broken inline blob on the docs site. Replace it with an inline Markdown-friendly description.

Also make `size` a required argument of `ChronosBolt.from_hf()` instead of defaulting to "base": the four sizes have different embedding dimensions, so a silent default was error-prone.


Claude-Session: https://claude.ai/code/session_01KEKNjm8oSYzw276okfggzc

- [ ] By submitting this pull request, I confirm that my contribution is licensed under both GPLv3 and MIT. The project is currently GPLv3 and is in the process of moving to MIT (see https://github.com/light-curve/light-curve-python/issues/742). Dual-licensing all new contributions now ensures a smooth transition.
