### PR TITLE
Add RainbowFit Python bindings (Rust-backed, ~11-17x faster than iminuit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   foundation model (Goswami et al. 2024, MIT license), exposing `mean` / `sequence` outputs.
   Available in small/base/large sizes (512/768/1024-dim) via `Moment1.from_hf(size=...)`; uses a
   fixed 512-observation context (64 patches of 8).
+- `light_curve.RainbowFit`: Rust-native counterpart of `light_curve_py.RainbowFit`, the
+  multiband Bazin/Sigmoid/Doublexp-envelope x Planck-family SED fit (Russeil et al. 2023,
+  arXiv:2310.02916). Fit with a bounded Levenberg-Marquardt optimizer and an analytic
+  Jacobian instead of iminuit/scipy. Takes bands as a `band_wave_cm` dict of name to
+  effective wavelength in cm (`from_nm`/`from_angstrom` alternate constructors also
+  provided), since it's the only multiband feature that needs a wavelength per band.
+  `bolometric='linexp'` and `spectral='blanketed'` aren't implemented yet; use
+  `light_curve_py.RainbowFit` for those. **Depends on an unreleased `light-curve-feature`
+  version** (temporarily pinned to a fork branch in `Cargo.toml`, opt-in via the `rainbow`
+  Cargo feature) pending upstream review.
 
 ### Changed
 

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
 [[package]]
 name = "light-curve-feature"
 version = "0.18.1"
-source = "git+https://github.com/erusseil/light-curve-feature.git?branch=add-rainbow-multicolor-fit#bd1f0ca341c42954f573736b69365d8b6bc4041d"
+source = "git+https://github.com/erusseil/light-curve-feature.git?branch=add-rainbow-multicolor-fit#7a22ca2edd10a9d48733df0b15d205e9c87f695a"
 dependencies = [
  "GSL",
  "ceres-solver",

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -88,6 +88,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-array"
 version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1220,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1619,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "levenberg-marquardt"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7a65739a815308eef33a6d8c78e435a7317305d5b0af0c8c465a2d7ac6fc6"
+dependencies = [
+ "cfg-if",
+ "nalgebra",
+ "num-traits",
+ "rustc_version",
+]
+
+[[package]]
 name = "lexical-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,8 +1736,7 @@ dependencies = [
 [[package]]
 name = "light-curve-feature"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d3a7f7feb58db41465a3618ee064859cb60377ab7ff7476da3ab52e932fe47"
+source = "git+https://github.com/erusseil/light-curve-feature.git?branch=add-rainbow-multicolor-fit#bd1f0ca341c42954f573736b69365d8b6bc4041d"
 dependencies = [
  "GSL",
  "ceres-solver",
@@ -1616,10 +1744,12 @@ dependencies = [
  "emcee",
  "enum_dispatch",
  "fftw",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy_static",
+ "levenberg-marquardt",
  "libm",
  "macro_const",
+ "nalgebra",
  "ndarray 0.17.2",
  "ndarray-stats",
  "num-complex",
@@ -1759,6 +1889,51 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+dependencies = [
+ "approx",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1919,6 +2094,17 @@ name = "num-lazy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ca66a13db1c179f8414c75ebad0351f1597ef0b291aa6e58f7af129321f0f58"
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2613,6 +2799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustfft"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +2882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2934,12 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -2829,6 +3039,19 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3291,6 +3514,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -33,6 +33,9 @@ ceres-system = ["light-curve-feature/ceres-system"]
 mkl = ["light-curve-feature/fftw-mkl"]
 gsl = ["light-curve-feature/gsl"]
 mimalloc = ["dep:mimalloc"]
+# RainbowFit, opt-in like the other optional backends. Requires the light-curve-feature
+# git override below, since it isn't released on crates.io yet.
+rainbow = ["light-curve-feature/rainbow"]
 
 [dependencies]
 const_format = "0.2.35"
@@ -78,6 +81,12 @@ comfy-table = "7"
 [dependencies.light-curve-feature]
 version = "0.18.1"
 default-features = false
+# TEMPORARY: pinned to the RainbowFit branch pending review of
+# https://github.com/light-curve/light-curve-feature (PR not yet open, branch pushed to
+# https://github.com/erusseil/light-curve-feature/tree/add-rainbow-multicolor-fit).
+# Swap back to a plain crates.io dependency once RainbowFit is merged and released.
+git = "https://github.com/erusseil/light-curve-feature.git"
+branch = "add-rainbow-multicolor-fit"
 
 [dependencies.light-curve-dmdt]
 version = "0.9.0"

--- a/light-curve/src/features.rs
+++ b/light-curve/src/features.rs
@@ -290,19 +290,69 @@ fn transform_parameter_doc(default: StockTransformer) -> String {
 
 type PyLightCurve<'a, T> = (Arr<'a, T>, Arr<'a, T>, Option<Arr<'a, T>>);
 
-/// A passband label: either a string name (e.g. "g", "r") or an integer ID.
+/// An owned passband carrying an explicit effective wavelength, used by [`RainbowFit`].
 ///
-/// Unifies [`lcf::StringPassband`] and [`lcf::LabeledPassband<i64>`] under a single type
-/// that satisfies [`PassbandTrait`], so [`lcf::MultiColorFeature`] can be parameterised with
-/// one concrete passband type regardless of how the user supplied the band labels.
+/// [`lcf::MonochromePassband`] borrows its name (`&'a str`), which doesn't fit `Passband`'s
+/// need to be owned and long-lived inside a Python object, so this is a small owned
+/// equivalent. `f64` has no total order in general, but wavelengths are validated positive
+/// and finite at construction time (see `parse_band_wave_cm`), so `partial_cmp` never
+/// returns `None` here.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub(crate) struct OwnedMonochromePassband {
+    name: String,
+    /// Effective wavelength, in cm.
+    wavelength_cm: f64,
+}
+
+impl PartialEq for OwnedMonochromePassband {
+    fn eq(&self, other: &Self) -> bool {
+        self.wavelength_cm == other.wavelength_cm
+    }
+}
+
+impl Eq for OwnedMonochromePassband {}
+
+impl PartialOrd for OwnedMonochromePassband {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OwnedMonochromePassband {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.wavelength_cm
+            .partial_cmp(&other.wavelength_cm)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+impl PassbandTrait for OwnedMonochromePassband {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn wavelength(&self) -> Option<f64> {
+        Some(self.wavelength_cm)
+    }
+}
+
+/// A passband label: either a string name (e.g. "g", "r"), an integer ID, or (for
+/// [`RainbowFit`], the only feature that needs it) a name with an explicit wavelength.
+///
+/// Unifies [`lcf::StringPassband`], [`lcf::LabeledPassband<i64>`] and
+/// [`OwnedMonochromePassband`] under a single type that satisfies [`PassbandTrait`], so
+/// [`lcf::MultiColorFeature`] can be parameterised with one concrete passband type
+/// regardless of how the user supplied the band labels.
 ///
 /// Serde uses the untagged representation: string bands serialise as bare JSON strings
-/// (e.g. `"g"`), integer bands as `{"label": 0}`.
+/// (e.g. `"g"`), integer bands as `{"label": 0}`, monochrome bands as
+/// `{"name": ..., "wavelength_cm": ...}`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub(crate) enum Passband {
     String(lcf::StringPassband),
     Integer(lcf::LabeledPassband<i64>),
+    Monochrome(OwnedMonochromePassband),
 }
 
 impl PassbandTrait for Passband {
@@ -310,6 +360,14 @@ impl PassbandTrait for Passband {
         match self {
             Passband::String(p) => p.name(),
             Passband::Integer(p) => p.name(),
+            Passband::Monochrome(p) => p.name(),
+        }
+    }
+
+    fn wavelength(&self) -> Option<f64> {
+        match self {
+            Passband::Monochrome(p) => p.wavelength(),
+            Passband::String(_) | Passband::Integer(_) => None,
         }
     }
 }
@@ -534,6 +592,39 @@ fn parse_bands(bands_py: &Bound<PyAny>) -> Res<Vec<Passband>> {
     }
 }
 
+/// Parse `RainbowFit`'s `band_wave_cm` constructor argument: a `dict` mapping band name to
+/// effective wavelength in cm.
+#[cfg(feature = "rainbow")]
+fn parse_band_wave_cm(band_wave_cm: &Bound<'_, pyo3::types::PyDict>) -> Res<Vec<Passband>> {
+    if band_wave_cm.is_empty() {
+        return Err(Exception::ValueError(
+            "band_wave_cm must not be empty".to_string(),
+        ));
+    }
+    band_wave_cm
+        .iter()
+        .map(|(key, value)| {
+            let name: String = key.extract().map_err(|_| {
+                Exception::TypeError("band_wave_cm keys must be strings".to_string())
+            })?;
+            let wavelength_cm: f64 = value.extract().map_err(|_| {
+                Exception::TypeError(format!(
+                    "band_wave_cm['{name}'] must be a float wavelength in cm"
+                ))
+            })?;
+            if !(wavelength_cm.is_finite() && wavelength_cm > 0.0) {
+                return Err(Exception::ValueError(format!(
+                    "band_wave_cm['{name}'] must be a positive finite wavelength, got {wavelength_cm}"
+                )));
+            }
+            Ok(Passband::Monochrome(OwnedMonochromePassband {
+                name,
+                wavelength_cm,
+            }))
+        })
+        .collect()
+}
+
 /// Pre-built per-dtype lookup tables for the fast numpy band-array path.
 ///
 /// The number of configured bands is small (typically ≤ 10), so a linear scan over a
@@ -743,13 +834,15 @@ fn make_sorted_bands_and_input(bands: &[Passband]) -> (Vec<Passband>, BandInput)
     let mut sorted = bands.to_vec();
     sorted.sort();
     let band_input = match sorted.first() {
-        None | Some(Passband::String(_)) => BandInput::String(build_band_lookup(&sorted)),
+        None | Some(Passband::String(_)) | Some(Passband::Monochrome(_)) => {
+            BandInput::String(build_band_lookup(&sorted))
+        }
         Some(Passband::Integer(_)) => {
             let sorted_ints: Vec<i64> = sorted
                 .iter()
                 .map(|p| match p {
                     Passband::Integer(lp) => lp.label,
-                    Passband::String(_) => unreachable!(),
+                    Passband::String(_) | Passband::Monochrome(_) => unreachable!(),
                 })
                 .collect();
             BandInput::Integer(IntBandLookup::build(&sorted_ints))
@@ -2628,7 +2721,7 @@ impl PyFeatureEvaluator {
                             .iter()
                             .map(|p| match p {
                                 Passband::Integer(lp) => lp.label,
-                                Passband::String(_) => unreachable!(),
+                                Passband::String(_) | Passband::Monochrome(_) => unreachable!(),
                             })
                             .collect();
                         Ok(Some(np.getattr("array")?.call1((ints,))?))
@@ -3815,6 +3908,281 @@ impl ColorSpread {
              Extract features and return them as a numpy array\n\
          many(self, lcs, *, fill_value=None, sorted=None, check=True, cast=False, n_jobs=-1)\n\
              Extract features from multiple light curves in parallel"
+    }
+}
+
+#[cfg(feature = "rainbow")]
+fn parse_bolometric(s: &str) -> Res<lcf::Bolometric> {
+    match s {
+        "bazin" => Ok(lcf::Bolometric::Bazin),
+        "sigmoid" => Ok(lcf::Bolometric::Sigmoid),
+        "doublexp" => Ok(lcf::Bolometric::Doublexp),
+        "linexp" => Err(Exception::NotImplementedError(
+            "bolometric='linexp' is not implemented in the Rust backend: the Python \
+             reference's own docstring flags its guesses/limits as unstable. Use 'bazin', \
+             'sigmoid', or 'doublexp', or use the pure-Python light_curve_py.RainbowFit."
+                .to_string(),
+        )),
+        other => Err(Exception::ValueError(format!(
+            "unknown bolometric term {other:?}; supported: 'bazin', 'sigmoid', 'doublexp'"
+        ))),
+    }
+}
+
+#[cfg(feature = "rainbow")]
+fn parse_temperature(s: &str) -> Res<lcf::Temperature> {
+    match s {
+        "constant" => Ok(lcf::Temperature::Constant),
+        "sigmoid" => Ok(lcf::Temperature::Sigmoid),
+        "delayed_sigmoid" => Ok(lcf::Temperature::DelayedSigmoid),
+        other => Err(Exception::ValueError(format!(
+            "unknown temperature term {other:?}; supported: 'constant', 'sigmoid', 'delayed_sigmoid'"
+        ))),
+    }
+}
+
+#[cfg(feature = "rainbow")]
+fn parse_spectral(s: &str) -> Res<lcf::Spectral> {
+    match s {
+        "planck" => Ok(lcf::Spectral::Planck),
+        "genwien" => Ok(lcf::Spectral::GenWien),
+        "modified_bb" => Ok(lcf::Spectral::ModifiedBlackBody),
+        "logparabola" => Ok(lcf::Spectral::LogParabola),
+        "blanketed" => Err(Exception::NotImplementedError(
+            "spectral='blanketed' is not implemented in the Rust backend: it anchors its \
+             extinction depth to the temperature term's own characteristic T parameter via \
+             cross-term sharing that hasn't been ported. Use 'planck', 'genwien', \
+             'modified_bb', or 'logparabola', or use the pure-Python light_curve_py.RainbowFit."
+                .to_string(),
+        )),
+        other => Err(Exception::ValueError(format!(
+            "unknown spectral term {other:?}; supported: 'planck', 'genwien', 'modified_bb', 'logparabola'"
+        ))),
+    }
+}
+
+/// Multiband blackbody fit to the light curve (Bazin/Sigmoid/Doublexp bolometric envelope
+/// times a Planck-family spectral energy distribution, with a temperature evolving over
+/// time). Based on Russeil et al. 2023, arXiv:2310.02916.
+///
+/// This is the Rust-native counterpart of `light_curve_py.RainbowFit`: same model and
+/// parametrization, but fit with a bounded Levenberg-Marquardt optimizer instead of
+/// iminuit/scipy, so it doesn't take an `optimizer=` argument and always uses its own
+/// analytic Jacobian. `linexp` (bolometric) and `blanketed` (spectral) are not implemented
+/// here yet -- use `light_curve_py.RainbowFit` for those.
+#[cfg(feature = "rainbow")]
+#[derive(Serialize, Deserialize)]
+#[pyclass(extends = PyFeatureEvaluator, module = "light_curve.light_curve_ext")]
+pub struct RainbowFit {
+    peak_time_eval: lcf::RainbowFit<Passband, f64>,
+}
+
+#[cfg(feature = "rainbow")]
+impl_pickle_serialisation!(RainbowFit);
+
+#[cfg(feature = "rainbow")]
+impl RainbowFit {
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        band_wave_cm: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<PyClassInitializer<Self>> {
+        if transform.is_some() {
+            return Err(Exception::NotImplementedError(
+                "RainbowFit does not support transform".to_string(),
+            ));
+        }
+        let bol = parse_bolometric(bolometric)?;
+        let temp = parse_temperature(temperature)?;
+        let spec = parse_spectral(spectral)?;
+        let user_bands = parse_band_wave_cm(band_wave_cm)?;
+
+        let peak_time_eval = lcf::RainbowFit::<Passband, f64>::new(
+            user_bands.iter().cloned(),
+            bol,
+            temp,
+            spec,
+            with_baseline,
+        )
+        .map_err(|err| Exception::ValueError(err.to_string()))?;
+        let mc_f32 = lcf::MultiColorFeature::RainbowFit(
+            lcf::RainbowFit::<Passband, f32>::new(
+                user_bands.iter().cloned(),
+                bol,
+                temp,
+                spec,
+                with_baseline,
+            )
+            .map_err(|err| Exception::ValueError(err.to_string()))?,
+        );
+        let mc_f64 = lcf::MultiColorFeature::RainbowFit(peak_time_eval.clone());
+
+        Ok(
+            PyClassInitializer::from(PyFeatureEvaluator::multi_band(user_bands, mc_f32, mc_f64))
+                .add_subclass(Self { peak_time_eval }),
+        )
+    }
+}
+
+#[cfg(feature = "rainbow")]
+#[pymethods]
+impl RainbowFit {
+    #[new]
+    #[pyo3(signature = (
+        band_wave_cm,
+        *,
+        bolometric = "bazin",
+        temperature = "sigmoid",
+        spectral = "planck",
+        with_baseline = true,
+        transform = None,
+    ))]
+    fn __new__(
+        band_wave_cm: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<PyClassInitializer<Self>> {
+        Self::build(
+            band_wave_cm,
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            transform,
+        )
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (
+        band_wave_nm,
+        *,
+        bolometric = "bazin",
+        temperature = "sigmoid",
+        spectral = "planck",
+        with_baseline = true,
+        transform = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_nm(
+        py: Python<'_>,
+        band_wave_nm: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<Py<Self>> {
+        let band_wave_cm = pyo3::types::PyDict::new(py);
+        for (name, wavelength_nm) in band_wave_nm.iter() {
+            let wavelength_nm: f64 = wavelength_nm.extract()?;
+            band_wave_cm.set_item(name, 1e-7 * wavelength_nm)?;
+        }
+        let initializer = Self::build(
+            &band_wave_cm,
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            transform,
+        )?;
+        Ok(Py::new(py, initializer)?)
+    }
+
+    /// Dummy args to satisfy `__new__` during unpickling; `__setstate__` overwrites the
+    /// resulting object's actual state right afterwards, so these values themselves never
+    /// surface to the user.
+    #[staticmethod]
+    fn __getnewargs__() -> (BTreeMap<&'static str, f64>,) {
+        (BTreeMap::from([("g", 5000e-8)]),)
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (
+        band_wave_aa,
+        *,
+        bolometric = "bazin",
+        temperature = "sigmoid",
+        spectral = "planck",
+        with_baseline = true,
+        transform = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_angstrom(
+        py: Python<'_>,
+        band_wave_aa: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<Py<Self>> {
+        let band_wave_cm = pyo3::types::PyDict::new(py);
+        for (name, wavelength_aa) in band_wave_aa.iter() {
+            let wavelength_aa: f64 = wavelength_aa.extract()?;
+            band_wave_cm.set_item(name, 1e-8 * wavelength_aa)?;
+        }
+        let initializer = Self::build(
+            &band_wave_cm,
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            transform,
+        )?;
+        Ok(Py::new(py, initializer)?)
+    }
+
+    /// Bolometric peak time for the given fitted parameters (same units as input `t`).
+    fn peak_time(&self, params: Vec<f64>) -> Option<f64> {
+        self.peak_time_eval.peak_time(&params)
+    }
+
+    #[classattr]
+    fn __doc__() -> &'static str {
+        "Multiband blackbody fit to the light curve using functions to be chosen by the user.\n\n\
+         Note that `m` and the corresponding `sigma` are assumed to be flux densities.\n\
+         Based on Russeil et al. 2023, arXiv:2310.02916.\n\n\
+         Parameters\n\
+         ----------\n\
+         band_wave_cm : dict\n\
+             Mapping of band names to their effective wavelengths, in cm.\n\
+         bolometric : str, default 'bazin'\n\
+             Shape of the bolometric term: 'bazin', 'sigmoid', or 'doublexp'.\n\
+         temperature : str, default 'sigmoid'\n\
+             Shape of the temperature-vs-time term: 'constant', 'sigmoid', or 'delayed_sigmoid'.\n\
+         spectral : str, default 'planck'\n\
+             Spectral energy distribution: 'planck', 'genwien', 'modified_bb', or 'logparabola'.\n\
+         with_baseline : bool, default True\n\
+             Whether to fit an additive per-band baseline offset alongside the model.\n\
+         \n\
+         Attributes\n\
+         ----------\n\
+         names : list of str\n\
+             Feature names: fitted parameters, then their uncertainties, then reduced Chi^2.\n\
+         descriptions : list of str\n\
+             Feature descriptions\n\
+         bands : numpy.ndarray of str\n\
+             Passband names, in `band_wave_cm` order\n\
+         \n\
+         Methods\n\
+         -------\n\
+         __call__(self, t, m, sigma=None, band=None, *, fill_value=None, sorted=None, check=True, cast=False)\n\
+             Extract features and return them as a numpy array\n\
+         many(self, lcs, *, fill_value=None, sorted=None, check=True, cast=False, n_jobs=-1)\n\
+             Extract features from multiple light curves in parallel\n\
+         peak_time(self, params)\n\
+             Bolometric peak time for the given fitted parameters\n\
+         from_nm(band_wave_nm, **kwargs)\n\
+             Alternate constructor: wavelengths given in nm instead of cm\n\
+         from_angstrom(band_wave_aa, **kwargs)\n\
+             Alternate constructor: wavelengths given in angstrom instead of cm"
     }
 }
 

--- a/light-curve/src/features.rs
+++ b/light-curve/src/features.rs
@@ -292,11 +292,9 @@ type PyLightCurve<'a, T> = (Arr<'a, T>, Arr<'a, T>, Option<Arr<'a, T>>);
 
 /// An owned passband carrying an explicit effective wavelength, used by [`RainbowFit`].
 ///
-/// [`lcf::MonochromePassband`] borrows its name (`&'a str`), which doesn't fit `Passband`'s
-/// need to be owned and long-lived inside a Python object, so this is a small owned
-/// equivalent. `f64` has no total order in general, but wavelengths are validated positive
-/// and finite at construction time (see `parse_band_wave_cm`), so `partial_cmp` never
-/// returns `None` here.
+/// [`lcf::MonochromePassband`] borrows its name, which doesn't fit `Passband`'s need to be
+/// owned and long-lived in a Python object. Wavelengths are validated positive and finite in
+/// `parse_band_wave_cm`, so `Ord`/`PartialOrd` below never hit the NaN case.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub(crate) struct OwnedMonochromePassband {
     name: String,

--- a/light-curve/src/lib.rs
+++ b/light-curve/src/lib.rs
@@ -89,6 +89,8 @@ fn light_curve(py: Python, m: Bound<PyModule>) -> PyResult<()> {
     m.add_class::<f::PercentAmplitude>()?;
     m.add_class::<f::PercentDifferenceMagnitudePercentile>()?;
     m.add_class::<f::Periodogram>()?;
+    #[cfg(feature = "rainbow")]
+    m.add_class::<f::RainbowFit>()?;
     m.add_class::<f::ReducedChi2>()?;
     m.add_class::<f::Roms>()?;
     m.add_class::<f::Skew>()?;

--- a/light-curve/tests/light_curve_ext/test_feature.py
+++ b/light-curve/tests/light_curve_ext/test_feature.py
@@ -56,12 +56,22 @@ def _try_pure_multiband(cls):
         return False
 
 
+# RainbowFit is multiband-only like the other pure multiband features, but its mandatory
+# argument is a `band_wave_cm` dict (name -> wavelength), not a plain `bands` list, so it's
+# special-cased everywhere `_MULTIBAND_BANDS` (a list) would otherwise be passed to it.
+_non_list_multiband_feature_classes = (
+    frozenset({licu_ext.RainbowFit}) if hasattr(licu_ext, "RainbowFit") else frozenset()
+)
+
 # Pure multiband features: always multiband-only, no single-band mode.
 # Their constructor takes `bands` as the first (and only mandatory) argument.
 pure_multiband_feature_classes = frozenset(
     cls
     for cls in all_feature_classes
-    if cls not in fit_feature_classes | {licu_ext.Extractor, licu_ext.Periodogram, licu_ext.JSONDeserializedFeature}
+    if cls
+    not in fit_feature_classes
+    | {licu_ext.Extractor, licu_ext.Periodogram, licu_ext.JSONDeserializedFeature}
+    | _non_list_multiband_feature_classes
     and hasattr(cls, "__getnewargs__")
     and _try_pure_multiband(cls)
 )
@@ -144,8 +154,10 @@ def construct_example_objects(cls, *, parametric_variants=1, rng=None):
     if cls is licu_ext.Extractor:
         return [cls(licu_ext.BeyondNStd(1.5), licu_ext.LinearFit())]
 
-    # Pure multiband features have no single-band mode; skip them here
-    if cls in pure_multiband_feature_classes:
+    # Pure multiband features have no single-band mode; skip them here. RainbowFit is pure
+    # multiband too, but takes `band_wave_cm` (a dict) rather than `bands` (a list) as its
+    # mandatory arg, so it's classified separately (see `_non_list_multiband_feature_classes`).
+    if cls in pure_multiband_feature_classes | _non_list_multiband_feature_classes:
         return []
 
     # Periodogram
@@ -204,7 +216,15 @@ _MULTIBAND_BANDS = ["g", "r"]
 
 def _try_construct_multiband(cls):
     """Return a multiband instance of *cls*, or None if not supported."""
-    if cls in fit_feature_classes or cls in (licu_ext.Extractor, licu_ext.Bins, licu_ext.JSONDeserializedFeature):
+    # RainbowFit is a nonlinear fit, like the `fit_feature_classes` below: fitting random
+    # noise (the generic multiband harness's test data) isn't guaranteed to converge, so it
+    # gets its own dedicated tests instead (see the "RainbowFit tests" section) rather than
+    # participating in this fully-generic one.
+    if (
+        cls in fit_feature_classes
+        or cls in (licu_ext.Extractor, licu_ext.Bins, licu_ext.JSONDeserializedFeature)
+        or cls in _non_list_multiband_feature_classes
+    ):
         return None
     if cls is licu_ext.Periodogram:
         return licu_ext.Periodogram(peaks=2, bands=_MULTIBAND_BANDS)
@@ -1985,3 +2005,125 @@ def test_benchmark_multiband_integer_bands(benchmark, _bench_int_feat, _bench_in
     benchmark.group = "multiband_band_dispatch"
     benchmark.name = "integer_bands"
     benchmark(lambda: _bench_int_feat(t, m, sigma, band, sorted=True, check=False))
+
+
+# ── RainbowFit tests ────────────────────────────────────────────────────────
+#
+# `rainbow` is an opt-in Cargo feature (not built by default yet, since it currently
+# depends on an unreleased light-curve-feature version), so every test below is skipped
+# when the extension wasn't built with it.
+
+requires_rainbow = pytest.mark.skipif(
+    not hasattr(licu_ext, "RainbowFit"),
+    reason="extension built without the `rainbow` Cargo feature",
+)
+
+
+def _rainbow_synthetic_lc(band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng):
+    """Bazin bolometric x Planck SED synthetic light curve, with 2% multiplicative noise."""
+    h, c, k_b = 6.62607004e-27, 2.99792458e10, 1.380649e-16
+    parts_t, parts_m, parts_s, parts_b = [], [], [], []
+    for name, wave_cm in band_wave_cm.items():
+        t = np.sort(rng.uniform(t0 - 3 * rise_time, t0 + 4 * fall_time, 50))
+        bol = amplitude * np.exp(-(t - t0) / fall_time) / (1 + np.exp(-(t - t0) / rise_time))
+        nu = c / wave_cm
+        planck = (2 * h * nu**3 / c**2) / np.expm1(h * nu / (k_b * temperature))
+        m = bol * planck * (1 + rng.normal(0, 0.02, t.size))
+        sigma = 0.02 * np.abs(m)
+        parts_t.append(t)
+        parts_m.append(m)
+        parts_s.append(sigma)
+        parts_b.extend([name] * t.size)
+    t = np.concatenate(parts_t)
+    m = np.concatenate(parts_m)
+    sigma = np.concatenate(parts_s)
+    band = np.array(parts_b)
+    idx = np.argsort(t)
+    return t[idx], m[idx], sigma[idx], band[idx]
+
+
+@requires_rainbow
+def test_rainbow_fit_recovers_injected_parameters():
+    """RainbowFit(bolometric='bazin', temperature='constant') recovers injected values."""
+    band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
+    t0, amplitude, rise_time, fall_time, temperature = 10.0, 100.0, 3.0, 15.0, 8000.0
+    rng = np.random.default_rng(1)
+    t, m, sigma, band = _rainbow_synthetic_lc(
+        band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng
+    )
+
+    feat = licu_ext.RainbowFit(
+        band_wave_cm, bolometric="bazin", temperature="constant", spectral="planck", with_baseline=False
+    )
+    result = feat(t, m, sigma, band)
+    values = dict(zip(feat.names, result))
+
+    assert_allclose(values["rainbow_reference_time"], t0, atol=1.0)
+    assert_allclose(values["rainbow_rise_time"], rise_time, rtol=0.3)
+    assert_allclose(values["rainbow_fall_time"], fall_time, rtol=0.2)
+    assert_allclose(values["rainbow_T"], temperature, rtol=0.1)
+    assert values["rainbow_reduced_chi2"] < 3.0
+
+
+@requires_rainbow
+def test_rainbow_fit_names_and_shape():
+    """Output layout is [params..., param_sigmas..., reduced_chi2]."""
+    feat = licu_ext.RainbowFit({"g": 4770e-8, "r": 6231e-8}, with_baseline=True)
+    n_params = (len(feat.names) - 1) // 2
+    assert feat.names[-1] == "rainbow_reduced_chi2"
+    assert feat.names[:n_params] == [n[: -len("_sigma")] for n in feat.names[n_params:-1]]
+    assert "rainbow_baseline_g" in feat.names
+    assert "rainbow_baseline_r" in feat.names
+
+
+@requires_rainbow
+def test_rainbow_fit_from_nm_and_from_angstrom_equivalent_to_cm():
+    """from_nm/from_angstrom are unit-converted shorthands for band_wave_cm."""
+    cm = licu_ext.RainbowFit({"g": 4770e-8, "r": 6231e-8})
+    nm = licu_ext.RainbowFit.from_nm({"g": 477.0, "r": 623.1})
+    aa = licu_ext.RainbowFit.from_angstrom({"g": 4770.0, "r": 6231.0})
+    assert cm.names == nm.names == aa.names
+
+
+@requires_rainbow
+def test_rainbow_fit_peak_time():
+    """peak_time() returns a finite time close to the fitted reference_time for a Bazin term."""
+    band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
+    rng = np.random.default_rng(2)
+    t, m, sigma, band = _rainbow_synthetic_lc(band_wave_cm, 10.0, 100.0, 3.0, 15.0, 8000.0, rng)
+    feat = licu_ext.RainbowFit(band_wave_cm, bolometric="bazin", temperature="constant", with_baseline=False)
+    result = feat(t, m, sigma, band)
+    n_params = (len(feat.names) - 1) // 2
+    peak = feat.peak_time(list(result[:n_params]))
+    assert np.isfinite(peak)
+
+
+@requires_rainbow
+def test_rainbow_fit_empty_bands_raises():
+    with pytest.raises(ValueError, match="not be empty"):
+        licu_ext.RainbowFit({})
+
+
+@requires_rainbow
+def test_rainbow_fit_unimplemented_terms_raise_not_implemented():
+    with pytest.raises(NotImplementedError):
+        licu_ext.RainbowFit({"g": 4770e-8}, bolometric="linexp")
+    with pytest.raises(NotImplementedError):
+        licu_ext.RainbowFit({"g": 4770e-8}, spectral="blanketed")
+
+
+@requires_rainbow
+def test_rainbow_fit_unknown_term_raises_value_error():
+    with pytest.raises(ValueError, match="unknown bolometric term"):
+        licu_ext.RainbowFit({"g": 4770e-8}, bolometric="not_a_term")
+
+
+@requires_rainbow
+def test_rainbow_fit_pickle_roundtrip():
+    band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
+    feat = licu_ext.RainbowFit(band_wave_cm, bolometric="bazin", temperature="constant", with_baseline=False)
+    restored = pickle.loads(pickle.dumps(feat))
+    assert restored.names == feat.names
+    rng = np.random.default_rng(5)
+    t, m, sigma, band = _rainbow_synthetic_lc(band_wave_cm, 10.0, 100.0, 3.0, 15.0, 8000.0, rng)
+    assert_allclose(feat(t, m, sigma, band), restored(t, m, sigma, band))

--- a/light-curve/tests/light_curve_ext/test_feature.py
+++ b/light-curve/tests/light_curve_ext/test_feature.py
@@ -2048,9 +2048,7 @@ def test_rainbow_fit_recovers_injected_parameters():
     band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
     t0, amplitude, rise_time, fall_time, temperature = 10.0, 100.0, 3.0, 15.0, 8000.0
     rng = np.random.default_rng(1)
-    t, m, sigma, band = _rainbow_synthetic_lc(
-        band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng
-    )
+    t, m, sigma, band = _rainbow_synthetic_lc(band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng)
 
     feat = licu_ext.RainbowFit(
         band_wave_cm, bolometric="bazin", temperature="constant", spectral="planck", with_baseline=False


### PR DESCRIPTION
## What

Rust-native PyO3 binding for `RainbowFit`, exposed as `light_curve.RainbowFit`. Companion to
**[https://github.com/light-curve/light-curve-feature/pull/314]**, which this depends on (see "Temporary dependency"
below) and should land first.

`light_curve.RainbowFit` is a drop-in-shadow of the existing `light_curve_py.RainbowFit`
(same import-layering convention as every other Rust-backed feature: Python versions import
first, Rust overrides at the same name), same model and parametrization, fit with the bounded
Levenberg-Marquardt optimizer from the companion PR instead of iminuit/scipy -- so it doesn't
take an `optimizer=` argument, and always uses its own analytic Jacobian.

```python
import light_curve as licu

feat = licu.RainbowFit({"g": 4770e-8, "r": 6231e-8}, bolometric="bazin", temperature="sigmoid")
# or: licu.RainbowFit.from_nm({...}) / licu.RainbowFit.from_angstrom({...})
result = feat(t, m, sigma, band, sorted=True)
```

Measured ~11-17x faster than `light_curve_py.RainbowFit` (iminuit) -- see the companion PR
for benchmark details.

## Why `band_wave_cm` instead of the usual `bands=`

Every other multiband feature in this package takes `bands=` (a plain list of names/ints);
`RainbowFit` is the only one that needs a wavelength per band, so it takes `band_wave_cm`
(a dict, matching `light_curve_py.RainbowFit`'s existing convention) instead, with
`from_nm`/`from_angstrom` convenience constructors. Under the hood, the shared `Passband` enum
gained an owned `Monochrome(name, wavelength_cm)` variant (other features still get plain
`String`/`Integer` passbands and never see this variant). Flagging this as the one
`light-curve-python`-side design choice worth a second look -- an alternative would be
extending every feature's `bands=` to optionally carry a wavelength, but that's a much larger
surface change for one feature's benefit.

## `bolometric='linexp'` / `spectral='blanketed'`

Not implemented in the Rust backend (see the companion PR for why); calling with either raises
a clear `NotImplementedError` pointing at `light_curve_py.RainbowFit` as the fallback.

## Temporary dependency (needs attention before merge)

`Cargo.toml`'s `light-curve-feature` dependency is currently git-pinned to the fork branch
from the companion PR (clearly commented as temporary), since `RainbowFit` isn't released on
crates.io yet. This PR shouldn't merge until that one does, at which point the pin should
revert to a normal crates.io version bump.

## Status

Full `tests/light_curve_ext/test_feature.py` suite passes (2110+ tests, including new
dedicated `RainbowFit` tests: construction, synthetic-parameter recovery, `from_nm`/
`from_angstrom`, `peak_time`, pickling, error paths), `cargo clippy -- -D warnings` and
`cargo fmt --check` clean. `RainbowFit` is opt-in via a new `rainbow` Cargo feature (not in
`default`, matching `gsl`/`ceres-source`'s pattern).