### PR TITLE
Rainbow fit wrapper v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   foundation model (Goswami et al. 2024, MIT license), exposing `mean` / `sequence` outputs.
   Available in small/base/large sizes (512/768/1024-dim) via `Moment1.from_hf(size=...)`; uses a
   fixed 512-observation context (64 patches of 8).
+- `light_curve.RainbowFit`: Rust-native counterpart of `light_curve_py.RainbowFit`, the
+  multiband Bazin/Sigmoid/Doublexp-envelope x Planck-family SED fit (Russeil et al. 2023,
+  arXiv:2310.02916). Fit through the same Ceres/MCMC/NUTS optimizer infrastructure as
+  `BazinFit`/`VillarFit` (`algorithm=` selects between them), instead of iminuit/scipy. Takes
+  bands as a `band_wave_cm` dict of name to effective wavelength in cm (`from_nm`/`from_angstrom`
+  alternate constructors also provided). `bolometric='linexp'` and `spectral='blanketed'` aren't
+  implemented yet; use `light_curve_py.RainbowFit` for those. **Depends on an unreleased
+  `light-curve-feature` version** (temporarily pinned to a fork branch in `Cargo.toml`) pending
+  upstream review.
 
 ### Changed
 

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "light-curve-feature"
 version = "0.18.1"
-source = "git+https://github.com/erusseil/light-curve-feature.git?branch=rainbow-on-nl-fit#77555980b9023bffc96a2406f5e01279c67081d5"
+source = "git+https://github.com/erusseil/light-curve-feature.git?branch=rainbow-on-nl-fit#4960d7a4900971d401743fc9f9229c803a520ed0"
 dependencies = [
  "GSL",
  "ceres-solver",

--- a/light-curve/Cargo.lock
+++ b/light-curve/Cargo.lock
@@ -1607,8 +1607,7 @@ dependencies = [
 [[package]]
 name = "light-curve-feature"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d3a7f7feb58db41465a3618ee064859cb60377ab7ff7476da3ab52e932fe47"
+source = "git+https://github.com/erusseil/light-curve-feature.git?branch=rainbow-on-nl-fit#77555980b9023bffc96a2406f5e01279c67081d5"
 dependencies = [
  "GSL",
  "ceres-solver",
@@ -1616,7 +1615,7 @@ dependencies = [
  "emcee",
  "enum_dispatch",
  "fftw",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy_static",
  "libm",
  "macro_const",
@@ -1635,6 +1634,7 @@ dependencies = [
  "rustfft",
  "schemars",
  "serde",
+ "smallvec",
  "special",
  "take_mut",
  "thiserror 2.0.18",

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -78,6 +78,12 @@ comfy-table = "7"
 [dependencies.light-curve-feature]
 version = "0.18.1"
 default-features = false
+# TEMPORARY: pinned to the RainbowFit branch pending review of
+# https://github.com/light-curve/light-curve-feature (branch to be pushed to
+# https://github.com/erusseil/light-curve-feature/tree/rainbow-on-nl-fit).
+# Swap back to a plain crates.io dependency once RainbowFit is merged and released.
+git = "https://github.com/erusseil/light-curve-feature.git"
+branch = "rainbow-on-nl-fit"
 
 [dependencies.light-curve-dmdt]
 version = "0.9.0"

--- a/light-curve/Cargo.toml
+++ b/light-curve/Cargo.toml
@@ -79,7 +79,7 @@ comfy-table = "7"
 version = "0.18.1"
 default-features = false
 # TEMPORARY: pinned to the RainbowFit branch pending review of
-# https://github.com/light-curve/light-curve-feature (branch to be pushed to
+# https://github.com/light-curve/light-curve-feature (branch pushed to
 # https://github.com/erusseil/light-curve-feature/tree/rainbow-on-nl-fit).
 # Swap back to a plain crates.io dependency once RainbowFit is merged and released.
 git = "https://github.com/erusseil/light-curve-feature.git"

--- a/light-curve/src/features.rs
+++ b/light-curve/src/features.rs
@@ -290,19 +290,64 @@ fn transform_parameter_doc(default: StockTransformer) -> String {
 
 type PyLightCurve<'a, T> = (Arr<'a, T>, Arr<'a, T>, Option<Arr<'a, T>>);
 
-/// A passband label: either a string name (e.g. "g", "r") or an integer ID.
+/// An owned passband carrying an explicit effective wavelength, used to build
+/// [`RainbowFit`]'s `(passband, wavelength_cm)` constructor pairs.
 ///
-/// Unifies [`lcf::StringPassband`] and [`lcf::LabeledPassband<i64>`] under a single type
-/// that satisfies [`PassbandTrait`], so [`lcf::MultiColorFeature`] can be parameterised with
-/// one concrete passband type regardless of how the user supplied the band labels.
+/// [`lcf::MonochromePassband`] borrows its name, which doesn't fit `Passband`'s need to be
+/// owned and long-lived in a Python object. Wavelengths are validated positive and finite in
+/// `parse_band_wave_cm`, so `Ord`/`PartialOrd` below never hit the NaN case.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub(crate) struct OwnedMonochromePassband {
+    name: String,
+    /// Effective wavelength, in cm.
+    wavelength_cm: f64,
+}
+
+impl PartialEq for OwnedMonochromePassband {
+    fn eq(&self, other: &Self) -> bool {
+        self.wavelength_cm == other.wavelength_cm
+    }
+}
+
+impl Eq for OwnedMonochromePassband {}
+
+impl PartialOrd for OwnedMonochromePassband {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OwnedMonochromePassband {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.wavelength_cm
+            .partial_cmp(&other.wavelength_cm)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+impl PassbandTrait for OwnedMonochromePassband {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A passband label: either a string name (e.g. "g", "r"), an integer ID, or (for
+/// [`RainbowFit`], the only feature that needs it) a name with an explicit wavelength.
+///
+/// Unifies [`lcf::StringPassband`], [`lcf::LabeledPassband<i64>`] and
+/// [`OwnedMonochromePassband`] under a single type that satisfies [`PassbandTrait`], so
+/// [`lcf::MultiColorFeature`] can be parameterised with one concrete passband type
+/// regardless of how the user supplied the band labels.
 ///
 /// Serde uses the untagged representation: string bands serialise as bare JSON strings
-/// (e.g. `"g"`), integer bands as `{"label": 0}`.
+/// (e.g. `"g"`), integer bands as `{"label": 0}`, monochrome bands as
+/// `{"name": ..., "wavelength_cm": ...}`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub(crate) enum Passband {
     String(lcf::StringPassband),
     Integer(lcf::LabeledPassband<i64>),
+    Monochrome(OwnedMonochromePassband),
 }
 
 impl PassbandTrait for Passband {
@@ -310,6 +355,7 @@ impl PassbandTrait for Passband {
         match self {
             Passband::String(p) => p.name(),
             Passband::Integer(p) => p.name(),
+            Passband::Monochrome(p) => p.name(),
         }
     }
 }
@@ -534,6 +580,44 @@ fn parse_bands(bands_py: &Bound<PyAny>) -> Res<Vec<Passband>> {
     }
 }
 
+/// Parse `RainbowFit`'s `band_wave_cm` constructor argument: a `dict` mapping band name to
+/// effective wavelength in cm, into `(passband, wavelength_cm)` pairs for
+/// [`lcf::RainbowFit::new`].
+fn parse_band_wave_cm(
+    band_wave_cm: &Bound<'_, pyo3::types::PyDict>,
+) -> Res<Vec<(Passband, f64)>> {
+    if band_wave_cm.is_empty() {
+        return Err(Exception::ValueError(
+            "band_wave_cm must not be empty".to_string(),
+        ));
+    }
+    band_wave_cm
+        .iter()
+        .map(|(key, value)| {
+            let name: String = key.extract().map_err(|_| {
+                Exception::TypeError("band_wave_cm keys must be strings".to_string())
+            })?;
+            let wavelength_cm: f64 = value.extract().map_err(|_| {
+                Exception::TypeError(format!(
+                    "band_wave_cm['{name}'] must be a float wavelength in cm"
+                ))
+            })?;
+            if !(wavelength_cm.is_finite() && wavelength_cm > 0.0) {
+                return Err(Exception::ValueError(format!(
+                    "band_wave_cm['{name}'] must be a positive finite wavelength, got {wavelength_cm}"
+                )));
+            }
+            Ok((
+                Passband::Monochrome(OwnedMonochromePassband {
+                    name,
+                    wavelength_cm,
+                }),
+                wavelength_cm,
+            ))
+        })
+        .collect()
+}
+
 /// Pre-built per-dtype lookup tables for the fast numpy band-array path.
 ///
 /// The number of configured bands is small (typically ≤ 10), so a linear scan over a
@@ -743,13 +827,15 @@ fn make_sorted_bands_and_input(bands: &[Passband]) -> (Vec<Passband>, BandInput)
     let mut sorted = bands.to_vec();
     sorted.sort();
     let band_input = match sorted.first() {
-        None | Some(Passband::String(_)) => BandInput::String(build_band_lookup(&sorted)),
+        None | Some(Passband::String(_)) | Some(Passband::Monochrome(_)) => {
+            BandInput::String(build_band_lookup(&sorted))
+        }
         Some(Passband::Integer(_)) => {
             let sorted_ints: Vec<i64> = sorted
                 .iter()
                 .map(|p| match p {
                     Passband::Integer(lp) => lp.label,
-                    Passband::String(_) => unreachable!(),
+                    Passband::String(_) | Passband::Monochrome(_) => unreachable!(),
                 })
                 .collect();
             BandInput::Integer(IntBandLookup::build(&sorted_ints))
@@ -2628,7 +2714,7 @@ impl PyFeatureEvaluator {
                             .iter()
                             .map(|p| match p {
                                 Passband::Integer(lp) => lp.label,
-                                Passband::String(_) => unreachable!(),
+                                Passband::String(_) | Passband::Monochrome(_) => unreachable!(),
                             })
                             .collect();
                         Ok(Some(np.getattr("array")?.call1((ints,))?))
@@ -2986,6 +3072,24 @@ const SUPPORTED_ALGORITHMS_CURVE_FIT: [&str; N_ALGO_CURVE_FIT] = [
     "nuts-lmsder",
 ];
 
+// `RainbowFit` doesn't offer Lmsder: it ignores box bounds, which `RainbowFit` relies on to
+// keep parameters physical (see `lcf::RainbowFit::new`'s own validation).
+const N_ALGO_RAINBOW_PURE_MCMC: usize = 1;
+const N_ALGO_RAINBOW_NUTS: usize = 1 + N_ALGO_CURVE_FIT_CERES / 2;
+const N_ALGO_RAINBOW: usize =
+    N_ALGO_CURVE_FIT_CERES + N_ALGO_RAINBOW_PURE_MCMC + N_ALGO_RAINBOW_NUTS;
+
+const SUPPORTED_ALGORITHMS_RAINBOW: [&str; N_ALGO_RAINBOW] = [
+    "mcmc",
+    #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+    "ceres",
+    #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+    "mcmc-ceres",
+    "nuts",
+    #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+    "nuts-ceres",
+];
+
 macro_const! {
     const FIT_METHOD_MODEL_DOC: &str = r#"model(t, params, *, cast=False)
     Underlying parametric model function
@@ -3184,15 +3288,14 @@ macro_rules! fit_evaluator {
                         FitLnPrior::Name(s) => match s.as_str() $ln_prior_by_str,
                         FitLnPrior::ListLnPrior1D(v) => {
                             let v: Vec<_> = v.into_iter().map(|py_ln_prior1d| py_ln_prior1d.0).collect();
-                            lcf::LnPrior::ind_components(
-                                v.try_into().map_err(|v: Vec<_>| Exception::ValueError(
-                                    format!(
-                                        "ln_prior must have length of {}, not {}",
-                                        $nparam,
-                                        v.len())
-                                    )
-                                )?
-                            ).into()
+                            if v.len() != $nparam {
+                                return Err(Exception::ValueError(format!(
+                                    "ln_prior must have length of {}, not {}",
+                                    $nparam,
+                                    v.len()
+                                )).into());
+                            }
+                            lcf::LnPrior::ind_components(v).into()
                         }
                     },
                     None => lcf::LnPrior::none().into(),
@@ -3815,6 +3918,441 @@ impl ColorSpread {
              Extract features and return them as a numpy array\n\
          many(self, lcs, *, fill_value=None, sorted=None, check=True, cast=False, n_jobs=-1)\n\
              Extract features from multiple light curves in parallel"
+    }
+}
+
+fn parse_bolometric(s: &str) -> Res<lcf::Bolometric> {
+    match s {
+        "bazin" => Ok(lcf::Bolometric::Bazin),
+        "sigmoid" => Ok(lcf::Bolometric::Sigmoid),
+        "doublexp" => Ok(lcf::Bolometric::Doublexp),
+        "linexp" => Err(Exception::NotImplementedError(
+            "bolometric='linexp' is not implemented in the Rust backend: the Python \
+             reference's own docstring flags its guesses/limits as unstable. Use 'bazin', \
+             'sigmoid', or 'doublexp', or use the pure-Python light_curve_py.RainbowFit."
+                .to_string(),
+        )),
+        other => Err(Exception::ValueError(format!(
+            "unknown bolometric term {other:?}; supported: 'bazin', 'sigmoid', 'doublexp'"
+        ))),
+    }
+}
+
+fn parse_temperature(s: &str) -> Res<lcf::Temperature> {
+    match s {
+        "constant" => Ok(lcf::Temperature::Constant),
+        "sigmoid" => Ok(lcf::Temperature::Sigmoid),
+        "delayed_sigmoid" => Ok(lcf::Temperature::DelayedSigmoid),
+        other => Err(Exception::ValueError(format!(
+            "unknown temperature term {other:?}; supported: 'constant', 'sigmoid', 'delayed_sigmoid'"
+        ))),
+    }
+}
+
+fn parse_spectral(s: &str) -> Res<lcf::Spectral> {
+    match s {
+        "planck" => Ok(lcf::Spectral::Planck),
+        "genwien" => Ok(lcf::Spectral::GenWien),
+        "modified_bb" => Ok(lcf::Spectral::ModifiedBlackBody),
+        "logparabola" => Ok(lcf::Spectral::LogParabola),
+        "blanketed" => Err(Exception::NotImplementedError(
+            "spectral='blanketed' is not implemented in the Rust backend: it anchors its \
+             extinction depth to the temperature term's own characteristic T parameter via \
+             cross-term sharing that hasn't been ported. Use 'planck', 'genwien', \
+             'modified_bb', or 'logparabola', or use the pure-Python light_curve_py.RainbowFit."
+                .to_string(),
+        )),
+        other => Err(Exception::ValueError(format!(
+            "unknown spectral term {other:?}; supported: 'planck', 'genwien', 'modified_bb', 'logparabola'"
+        ))),
+    }
+}
+
+/// Multiband blackbody fit to the light curve (Bazin/Sigmoid/Doublexp bolometric envelope
+/// times a Planck-family spectral energy distribution, with a temperature evolving over
+/// time). Based on Russeil et al. 2023, arXiv:2310.02916.
+///
+/// This is the Rust-native counterpart of `light_curve_py.RainbowFit`: same model and
+/// parametrization, fit through the same Ceres/MCMC/NUTS optimizer infrastructure as
+/// `BazinFit`/`VillarFit` instead of iminuit/scipy. `linexp` (bolometric) and `blanketed`
+/// (spectral) are not implemented here yet -- use `light_curve_py.RainbowFit` for those.
+#[derive(Serialize, Deserialize)]
+#[pyclass(extends = PyFeatureEvaluator, module = "light_curve.light_curve_ext")]
+pub struct RainbowFit {
+    peak_time_eval: lcf::RainbowFit<Passband, f64>,
+}
+
+impl_pickle_serialisation!(RainbowFit);
+
+impl RainbowFit {
+    fn supported_algorithms_str() -> String {
+        SUPPORTED_ALGORITHMS_RAINBOW.join(", ")
+    }
+
+    fn default_ceres_iterations() -> Option<u16> {
+        #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+        {
+            lcf::CeresCurveFit::default_niterations().into()
+        }
+        #[cfg(not(any(feature = "ceres-source", feature = "ceres-system")))]
+        {
+            None
+        }
+    }
+
+    fn default_nuts_ntune() -> u32 {
+        lcf::NutsCurveFit::default_num_tune()
+    }
+
+    fn default_nuts_niter() -> u32 {
+        lcf::NutsCurveFit::default_num_draws()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        band_wave_cm: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        algorithm: &str,
+        mcmc_niter: Option<u32>,
+        // The first Option is for Python's None, the second is for compile-time None from
+        // Self::default_ceres_iterations()
+        ceres_niter: Option<Option<u16>>,
+        ceres_loss_reg: Option<f64>,
+        nuts_ntune: u32,
+        nuts_niter: u32,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<PyClassInitializer<Self>> {
+        if transform.is_some() {
+            return Err(Exception::NotImplementedError(
+                "RainbowFit does not support transform".to_string(),
+            ));
+        }
+        let bol = parse_bolometric(bolometric)?;
+        let temp = parse_temperature(temperature)?;
+        let spec = parse_spectral(spectral)?;
+        let band_wavelength_pairs = parse_band_wave_cm(band_wave_cm)?;
+        let user_bands: Vec<Passband> = band_wavelength_pairs
+            .iter()
+            .map(|(p, _)| p.clone())
+            .collect();
+
+        let mcmc_niter = mcmc_niter.unwrap_or_else(lcf::McmcCurveFit::default_niterations);
+
+        #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+        let ceres_fit: lcf::CurveFitAlgorithm = lcf::CeresCurveFit::new(
+            ceres_niter
+                .unwrap_or_else(Self::default_ceres_iterations)
+                .expect("logical error: default ceres_niter is None but Ceres is enabled"),
+            ceres_loss_reg.or_else(lcf::CeresCurveFit::default_loss_factor),
+        )
+        .into();
+        #[cfg(not(any(feature = "ceres-source", feature = "ceres-system")))]
+        if ceres_niter.flatten().is_some() || ceres_loss_reg.is_some() {
+            return Err(Exception::ValueError(
+                "Compiled without Ceres support, ceres_niter and ceres_loss_reg are not supported"
+                    .to_string(),
+            ));
+        }
+
+        let curve_fit_algorithm: lcf::CurveFitAlgorithm = match algorithm {
+            "mcmc" => lcf::McmcCurveFit::new(mcmc_niter, None).into(),
+            #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+            "ceres" => ceres_fit,
+            #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+            "mcmc-ceres" => lcf::McmcCurveFit::new(mcmc_niter, Some(ceres_fit)).into(),
+            "nuts" => lcf::NutsCurveFit::new(nuts_ntune, nuts_niter, None).into(),
+            #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+            "nuts-ceres" => lcf::NutsCurveFit::new(nuts_ntune, nuts_niter, Some(ceres_fit)).into(),
+            _ => {
+                return Err(Exception::ValueError(format!(
+                    r#"wrong algorithm value "{}", supported values are: {}"#,
+                    algorithm,
+                    Self::supported_algorithms_str()
+                )));
+            }
+        };
+
+        let peak_time_eval = lcf::RainbowFit::<Passband, f64>::new(
+            band_wavelength_pairs.iter().cloned(),
+            bol,
+            temp,
+            spec,
+            with_baseline,
+            curve_fit_algorithm.clone(),
+        )
+        .map_err(|err| Exception::ValueError(err.to_string()))?;
+        let mc_f32 = lcf::MultiColorFeature::RainbowFit(
+            lcf::RainbowFit::<Passband, f32>::new(
+                band_wavelength_pairs.iter().cloned(),
+                bol,
+                temp,
+                spec,
+                with_baseline,
+                curve_fit_algorithm.clone(),
+            )
+            .map_err(|err| Exception::ValueError(err.to_string()))?,
+        );
+        let mc_f64 = lcf::MultiColorFeature::RainbowFit(peak_time_eval.clone());
+
+        Ok(
+            PyClassInitializer::from(PyFeatureEvaluator::multi_band(user_bands, mc_f32, mc_f64))
+                .add_subclass(Self { peak_time_eval }),
+        )
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[pymethods]
+impl RainbowFit {
+    #[new]
+    #[pyo3(signature = (
+        band_wave_cm,
+        *,
+        bolometric = "bazin",
+        temperature = "sigmoid",
+        spectral = "planck",
+        with_baseline = true,
+        algorithm = "mcmc",
+        mcmc_niter = None,
+        ceres_niter = Self::default_ceres_iterations(),
+        ceres_loss_reg = None,
+        nuts_ntune = Self::default_nuts_ntune(),
+        nuts_niter = Self::default_nuts_niter(),
+        transform = None,
+    ))]
+    fn __new__(
+        band_wave_cm: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        algorithm: &str,
+        mcmc_niter: Option<u32>,
+        ceres_niter: Option<Option<u16>>,
+        ceres_loss_reg: Option<f64>,
+        nuts_ntune: u32,
+        nuts_niter: u32,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<PyClassInitializer<Self>> {
+        Self::build(
+            band_wave_cm,
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            algorithm,
+            mcmc_niter,
+            ceres_niter,
+            ceres_loss_reg,
+            nuts_ntune,
+            nuts_niter,
+            transform,
+        )
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (
+        band_wave_nm,
+        *,
+        bolometric = "bazin",
+        temperature = "sigmoid",
+        spectral = "planck",
+        with_baseline = true,
+        algorithm = "mcmc",
+        mcmc_niter = None,
+        ceres_niter = Self::default_ceres_iterations(),
+        ceres_loss_reg = None,
+        nuts_ntune = Self::default_nuts_ntune(),
+        nuts_niter = Self::default_nuts_niter(),
+        transform = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_nm(
+        py: Python<'_>,
+        band_wave_nm: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        algorithm: &str,
+        mcmc_niter: Option<u32>,
+        ceres_niter: Option<Option<u16>>,
+        ceres_loss_reg: Option<f64>,
+        nuts_ntune: u32,
+        nuts_niter: u32,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<Py<Self>> {
+        let band_wave_cm = pyo3::types::PyDict::new(py);
+        for (name, wavelength_nm) in band_wave_nm.iter() {
+            let wavelength_nm: f64 = wavelength_nm.extract()?;
+            band_wave_cm.set_item(name, 1e-7 * wavelength_nm)?;
+        }
+        let initializer = Self::build(
+            &band_wave_cm,
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            algorithm,
+            mcmc_niter,
+            ceres_niter,
+            ceres_loss_reg,
+            nuts_ntune,
+            nuts_niter,
+            transform,
+        )?;
+        Ok(Py::new(py, initializer)?)
+    }
+
+    /// Dummy args to satisfy `__new__` during unpickling; `__setstate__` overwrites the
+    /// resulting object's actual state right afterwards, so these values themselves never
+    /// surface to the user.
+    #[staticmethod]
+    fn __getnewargs__() -> (BTreeMap<&'static str, f64>,) {
+        (BTreeMap::from([("g", 5000e-8)]),)
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (
+        band_wave_aa,
+        *,
+        bolometric = "bazin",
+        temperature = "sigmoid",
+        spectral = "planck",
+        with_baseline = true,
+        algorithm = "mcmc",
+        mcmc_niter = None,
+        ceres_niter = Self::default_ceres_iterations(),
+        ceres_loss_reg = None,
+        nuts_ntune = Self::default_nuts_ntune(),
+        nuts_niter = Self::default_nuts_niter(),
+        transform = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_angstrom(
+        py: Python<'_>,
+        band_wave_aa: &Bound<'_, pyo3::types::PyDict>,
+        bolometric: &str,
+        temperature: &str,
+        spectral: &str,
+        with_baseline: bool,
+        algorithm: &str,
+        mcmc_niter: Option<u32>,
+        ceres_niter: Option<Option<u16>>,
+        ceres_loss_reg: Option<f64>,
+        nuts_ntune: u32,
+        nuts_niter: u32,
+        transform: Option<Bound<PyAny>>,
+    ) -> Res<Py<Self>> {
+        let band_wave_cm = pyo3::types::PyDict::new(py);
+        for (name, wavelength_aa) in band_wave_aa.iter() {
+            let wavelength_aa: f64 = wavelength_aa.extract()?;
+            band_wave_cm.set_item(name, 1e-8 * wavelength_aa)?;
+        }
+        let initializer = Self::build(
+            &band_wave_cm,
+            bolometric,
+            temperature,
+            spectral,
+            with_baseline,
+            algorithm,
+            mcmc_niter,
+            ceres_niter,
+            ceres_loss_reg,
+            nuts_ntune,
+            nuts_niter,
+            transform,
+        )?;
+        Ok(Py::new(py, initializer)?)
+    }
+
+    /// Bolometric peak time for the given fitted parameters (same units as input `t`).
+    fn peak_time(&self, params: Vec<f64>) -> Option<f64> {
+        self.peak_time_eval.peak_time(&params)
+    }
+
+    #[classattr]
+    fn supported_algorithms() -> [&'static str; N_ALGO_RAINBOW] {
+        SUPPORTED_ALGORITHMS_RAINBOW
+    }
+
+    #[classattr]
+    fn __doc__() -> String {
+        #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
+        let ceres_args = format!(
+            r#"ceres_niter : int, default {niter}
+    Number of Ceres iterations
+
+ceres_loss_reg : float or None, default None
+    Ceres loss regularization. If set to a number, the loss function is
+    regularized to discriminate outlier residuals larger than this value.
+    ``None`` means no regularization.
+
+"#,
+            niter = lcf::CeresCurveFit::default_niterations()
+        );
+        #[cfg(not(any(feature = "ceres-source", feature = "ceres-system")))]
+        let ceres_args = "";
+
+        format!(
+            r#"Multiband blackbody fit to the light curve using functions to be chosen by the user.
+
+Note that `m` and the corresponding `sigma` are assumed to be flux densities.
+Based on Russeil et al. 2023, arXiv:2310.02916.
+
+Parameters
+----------
+band_wave_cm : dict
+    Mapping of band names to their effective wavelengths, in cm.
+bolometric : str, default 'bazin'
+    Shape of the bolometric term: 'bazin', 'sigmoid', or 'doublexp'.
+temperature : str, default 'sigmoid'
+    Shape of the temperature-vs-time term: 'constant', 'sigmoid', or 'delayed_sigmoid'.
+spectral : str, default 'planck'
+    Spectral energy distribution: 'planck', 'genwien', 'modified_bb', or 'logparabola'.
+with_baseline : bool, default True
+    Whether to fit an additive per-band baseline offset alongside the model.
+algorithm : str, default 'mcmc'
+    Non-linear least-square algorithm, supported values are: {supported_algo}. Note that
+    'lmsder'/'mcmc-lmsder'/'nuts-lmsder' are not offered here: they ignore box bounds, which
+    this feature relies on to keep parameters physical.
+mcmc_niter : int or None, default None
+    Number of MCMC iterations
+
+{ceres_args}nuts_ntune : int, default {nuts_ntune}
+    Number of NUTS tuning iterations
+
+nuts_niter : int, default {nuts_niter}
+    Number of NUTS iterations
+
+Attributes
+----------
+names : list of str
+    Feature names: fitted parameters, then reduced Chi^2.
+descriptions : list of str
+    Feature descriptions
+bands : numpy.ndarray of str
+    Passband names, in `band_wave_cm` order
+
+Methods
+-------
+__call__(self, t, m, sigma=None, band=None, *, fill_value=None, sorted=None, check=True, cast=False)
+    Extract features and return them as a numpy array
+many(self, lcs, *, fill_value=None, sorted=None, check=True, cast=False, n_jobs=-1)
+    Extract features from multiple light curves in parallel
+peak_time(self, params)
+    Bolometric peak time for the given fitted parameters
+from_nm(band_wave_nm, **kwargs)
+    Alternate constructor: wavelengths given in nm instead of cm
+from_angstrom(band_wave_aa, **kwargs)
+    Alternate constructor: wavelengths given in angstrom instead of cm"#,
+            supported_algo = Self::supported_algorithms_str(),
+            nuts_ntune = Self::default_nuts_ntune(),
+            nuts_niter = Self::default_nuts_niter(),
+        )
     }
 }
 

--- a/light-curve/src/features.rs
+++ b/light-curve/src/features.rs
@@ -583,9 +583,7 @@ fn parse_bands(bands_py: &Bound<PyAny>) -> Res<Vec<Passband>> {
 /// Parse `RainbowFit`'s `band_wave_cm` constructor argument: a `dict` mapping band name to
 /// effective wavelength in cm, into `(passband, wavelength_cm)` pairs for
 /// [`lcf::RainbowFit::new`].
-fn parse_band_wave_cm(
-    band_wave_cm: &Bound<'_, pyo3::types::PyDict>,
-) -> Res<Vec<(Passband, f64)>> {
+fn parse_band_wave_cm(band_wave_cm: &Bound<'_, pyo3::types::PyDict>) -> Res<Vec<(Passband, f64)>> {
     if band_wave_cm.is_empty() {
         return Err(Exception::ValueError(
             "band_wave_cm must not be empty".to_string(),
@@ -3989,10 +3987,14 @@ impl RainbowFit {
         SUPPORTED_ALGORITHMS_RAINBOW.join(", ")
     }
 
+    /// Higher than the generic `CeresCurveFit::default_niterations()` (10), which is tuned for
+    /// simpler single-band features: Rainbow's larger multi-band parameter space needs more to
+    /// reach a comparable optimum (25/90 vs. 82/90 real light curves converging close to the
+    /// Python reference at niter=10 vs. niter=200).
     fn default_ceres_iterations() -> Option<u16> {
         #[cfg(any(feature = "ceres-source", feature = "ceres-system"))]
         {
-            lcf::CeresCurveFit::default_niterations().into()
+            Some(200)
         }
         #[cfg(not(any(feature = "ceres-source", feature = "ceres-system")))]
         {

--- a/light-curve/src/lib.rs
+++ b/light-curve/src/lib.rs
@@ -89,6 +89,7 @@ fn light_curve(py: Python, m: Bound<PyModule>) -> PyResult<()> {
     m.add_class::<f::PercentAmplitude>()?;
     m.add_class::<f::PercentDifferenceMagnitudePercentile>()?;
     m.add_class::<f::Periodogram>()?;
+    m.add_class::<f::RainbowFit>()?;
     m.add_class::<f::ReducedChi2>()?;
     m.add_class::<f::Roms>()?;
     m.add_class::<f::Skew>()?;

--- a/light-curve/tests/light_curve_ext/test_feature.py
+++ b/light-curve/tests/light_curve_ext/test_feature.py
@@ -56,12 +56,20 @@ def _try_pure_multiband(cls):
         return False
 
 
+# RainbowFit is multiband-only like the other pure multiband features, but its mandatory
+# argument is a `band_wave_cm` dict (name -> wavelength), not a plain `bands` list, so it's
+# special-cased everywhere `_MULTIBAND_BANDS` (a list) would otherwise be passed to it.
+_non_list_multiband_feature_classes = frozenset({licu_ext.RainbowFit})
+
 # Pure multiband features: always multiband-only, no single-band mode.
 # Their constructor takes `bands` as the first (and only mandatory) argument.
 pure_multiband_feature_classes = frozenset(
     cls
     for cls in all_feature_classes
-    if cls not in fit_feature_classes | {licu_ext.Extractor, licu_ext.Periodogram, licu_ext.JSONDeserializedFeature}
+    if cls
+    not in fit_feature_classes
+    | {licu_ext.Extractor, licu_ext.Periodogram, licu_ext.JSONDeserializedFeature}
+    | _non_list_multiband_feature_classes
     and hasattr(cls, "__getnewargs__")
     and _try_pure_multiband(cls)
 )
@@ -144,8 +152,10 @@ def construct_example_objects(cls, *, parametric_variants=1, rng=None):
     if cls is licu_ext.Extractor:
         return [cls(licu_ext.BeyondNStd(1.5), licu_ext.LinearFit())]
 
-    # Pure multiband features have no single-band mode; skip them here
-    if cls in pure_multiband_feature_classes:
+    # Pure multiband features have no single-band mode; skip them here. RainbowFit is pure
+    # multiband too, but takes `band_wave_cm` (a dict) rather than `bands` (a list) as its
+    # mandatory arg, so it's classified separately (see `_non_list_multiband_feature_classes`).
+    if cls in pure_multiband_feature_classes | _non_list_multiband_feature_classes:
         return []
 
     # Periodogram
@@ -204,7 +214,15 @@ _MULTIBAND_BANDS = ["g", "r"]
 
 def _try_construct_multiband(cls):
     """Return a multiband instance of *cls*, or None if not supported."""
-    if cls in fit_feature_classes or cls in (licu_ext.Extractor, licu_ext.Bins, licu_ext.JSONDeserializedFeature):
+    # RainbowFit is a nonlinear fit, like the `fit_feature_classes` below: fitting random
+    # noise (the generic multiband harness's test data) isn't guaranteed to converge, so it
+    # gets its own dedicated tests instead (see the "RainbowFit tests" section) rather than
+    # participating in this fully-generic one.
+    if (
+        cls in fit_feature_classes
+        or cls in (licu_ext.Extractor, licu_ext.Bins, licu_ext.JSONDeserializedFeature)
+        or cls in _non_list_multiband_feature_classes
+    ):
         return None
     if cls is licu_ext.Periodogram:
         return licu_ext.Periodogram(peaks=2, bands=_MULTIBAND_BANDS)
@@ -1985,3 +2003,126 @@ def test_benchmark_multiband_integer_bands(benchmark, _bench_int_feat, _bench_in
     benchmark.group = "multiband_band_dispatch"
     benchmark.name = "integer_bands"
     benchmark(lambda: _bench_int_feat(t, m, sigma, band, sorted=True, check=False))
+
+
+# ── RainbowFit tests ────────────────────────────────────────────────────────
+
+
+def _rainbow_synthetic_lc(band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng):
+    """Bazin bolometric x Planck SED synthetic light curve, with 2% multiplicative noise."""
+    h, c, k_b = 6.62607004e-27, 2.99792458e10, 1.380649e-16
+    parts_t, parts_m, parts_s, parts_b = [], [], [], []
+    for name, wave_cm in band_wave_cm.items():
+        t = np.sort(rng.uniform(t0 - 3 * rise_time, t0 + 4 * fall_time, 50))
+        bol = amplitude * np.exp(-(t - t0) / fall_time) / (1 + np.exp(-(t - t0) / rise_time))
+        nu = c / wave_cm
+        planck = (2 * h * nu**3 / c**2) / np.expm1(h * nu / (k_b * temperature))
+        m = bol * planck * (1 + rng.normal(0, 0.02, t.size))
+        sigma = 0.02 * np.abs(m)
+        parts_t.append(t)
+        parts_m.append(m)
+        parts_s.append(sigma)
+        parts_b.extend([name] * t.size)
+    t = np.concatenate(parts_t)
+    m = np.concatenate(parts_m)
+    sigma = np.concatenate(parts_s)
+    band = np.array(parts_b)
+    idx = np.argsort(t)
+    return t[idx], m[idx], sigma[idx], band[idx]
+
+
+def test_rainbow_fit_recovers_injected_parameters():
+    """RainbowFit(bolometric='bazin', temperature='constant') recovers injected values.
+
+    Uses algorithm='ceres': the default 'mcmc' needs many more iterations than its default
+    to converge tightly on this data, which isn't what this test is checking.
+    """
+    band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
+    t0, amplitude, rise_time, fall_time, temperature = 10.0, 100.0, 3.0, 15.0, 8000.0
+    rng = np.random.default_rng(1)
+    t, m, sigma, band = _rainbow_synthetic_lc(
+        band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng
+    )
+
+    feat = licu_ext.RainbowFit(
+        band_wave_cm,
+        bolometric="bazin",
+        temperature="constant",
+        spectral="planck",
+        with_baseline=False,
+        algorithm="ceres",
+    )
+    result = feat(t, m, sigma, band)
+    values = dict(zip(feat.names, result))
+
+    assert_allclose(values["rainbow_reference_time"], t0, atol=1.0)
+    assert_allclose(values["rainbow_rise_time"], rise_time, rtol=0.3)
+    assert_allclose(values["rainbow_fall_time"], fall_time, rtol=0.2)
+    assert_allclose(values["rainbow_T"], temperature, rtol=0.1)
+    assert values["rainbow_reduced_chi2"] < 3.0
+
+
+def test_rainbow_fit_names_and_shape():
+    """Output layout is [params..., reduced_chi2]."""
+    feat = licu_ext.RainbowFit({"g": 4770e-8, "r": 6231e-8}, with_baseline=True)
+    assert feat.names[-1] == "rainbow_reduced_chi2"
+    assert "rainbow_baseline_g" in feat.names
+    assert "rainbow_baseline_r" in feat.names
+    assert not any(name.endswith("_sigma") for name in feat.names)
+
+
+def test_rainbow_fit_from_nm_and_from_angstrom_equivalent_to_cm():
+    """from_nm/from_angstrom are unit-converted shorthands for band_wave_cm."""
+    cm = licu_ext.RainbowFit({"g": 4770e-8, "r": 6231e-8})
+    nm = licu_ext.RainbowFit.from_nm({"g": 477.0, "r": 623.1})
+    aa = licu_ext.RainbowFit.from_angstrom({"g": 4770.0, "r": 6231.0})
+    assert cm.names == nm.names == aa.names
+
+
+def test_rainbow_fit_peak_time():
+    """peak_time() returns a finite time close to the fitted reference_time for a Bazin term."""
+    band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
+    rng = np.random.default_rng(2)
+    t, m, sigma, band = _rainbow_synthetic_lc(band_wave_cm, 10.0, 100.0, 3.0, 15.0, 8000.0, rng)
+    feat = licu_ext.RainbowFit(
+        band_wave_cm, bolometric="bazin", temperature="constant", with_baseline=False, algorithm="ceres"
+    )
+    result = feat(t, m, sigma, band)
+    n_params = len(feat.names) - 1
+    peak = feat.peak_time(list(result[:n_params]))
+    assert np.isfinite(peak)
+
+
+def test_rainbow_fit_empty_bands_raises():
+    with pytest.raises(ValueError, match="not be empty"):
+        licu_ext.RainbowFit({})
+
+
+def test_rainbow_fit_unimplemented_terms_raise_not_implemented():
+    with pytest.raises(NotImplementedError):
+        licu_ext.RainbowFit({"g": 4770e-8}, bolometric="linexp")
+    with pytest.raises(NotImplementedError):
+        licu_ext.RainbowFit({"g": 4770e-8}, spectral="blanketed")
+
+
+def test_rainbow_fit_unknown_term_raises_value_error():
+    with pytest.raises(ValueError, match="unknown bolometric term"):
+        licu_ext.RainbowFit({"g": 4770e-8}, bolometric="not_a_term")
+
+
+def test_rainbow_fit_lmsder_not_supported():
+    """Lmsder ignores box bounds, which RainbowFit relies on; it isn't offered as an option."""
+    with pytest.raises(ValueError, match="wrong algorithm value"):
+        licu_ext.RainbowFit({"g": 4770e-8}, algorithm="lmsder")
+
+
+def test_rainbow_fit_pickle_roundtrip():
+    band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
+    feat = licu_ext.RainbowFit(
+        band_wave_cm, bolometric="bazin", temperature="constant", with_baseline=False, algorithm="ceres"
+    )
+    restored = pickle.loads(pickle.dumps(feat))
+    assert restored.names == feat.names
+    rng = np.random.default_rng(5)
+    t, m, sigma, band = _rainbow_synthetic_lc(band_wave_cm, 10.0, 100.0, 3.0, 15.0, 8000.0, rng)
+    assert_allclose(feat(t, m, sigma, band), restored(t, m, sigma, band))

--- a/light-curve/tests/light_curve_ext/test_feature.py
+++ b/light-curve/tests/light_curve_ext/test_feature.py
@@ -2040,9 +2040,7 @@ def test_rainbow_fit_recovers_injected_parameters():
     band_wave_cm = {"g": 4770e-8, "r": 6231e-8}
     t0, amplitude, rise_time, fall_time, temperature = 10.0, 100.0, 3.0, 15.0, 8000.0
     rng = np.random.default_rng(1)
-    t, m, sigma, band = _rainbow_synthetic_lc(
-        band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng
-    )
+    t, m, sigma, band = _rainbow_synthetic_lc(band_wave_cm, t0, amplitude, rise_time, fall_time, temperature, rng)
 
     feat = licu_ext.RainbowFit(
         band_wave_cm,


### PR DESCRIPTION
Rust-native `light_curve.RainbowFit`, the Python binding for the `RainbowFit` feature landing in
[light-curve-feature#TODO](https://github.com/light-curve/light-curve-feature).

```python
feat = light_curve.RainbowFit(
    band_wave_cm={"g": 4770e-8, "r": 6231e-8},
    bolometric="bazin", temperature="sigmoid", spectral="planck",
    algorithm="ceres",
)
result = feat(t, m, sigma, band)
```

- `band_wave_cm` (dict of band name -> wavelength in cm) is a mandatory constructor argument;
  `from_nm`/`from_angstrom` alternate constructors take the same mapping in nm/angstrom.
- `algorithm=` selects the non-linear solver, same convention as `BazinFit`/`VillarFit`
  (`"mcmc"`, `"ceres"`, `"mcmc-ceres"`, `"nuts"`, `"nuts-ceres"` -- `"lmsder"` isn't offered, see
  the core crate PR for why). Ceres defaults to 200 iterations here (vs. 10 for other features):
  Rainbow's larger parameter space needs it.
- Output is `[params..., reduced_chi2]`, matching `light_curve_py.RainbowFit.__call__`'s own
  convention -- no uncertainty columns.
- Always compiled in, no opt-in Cargo feature.

Same priority as the core crate PR: land on the existing structure first, tune convergence
after. On 90 real, multi-band, uneven-cadence light curves, 82/90 converge within a few x of
`light_curve_py`'s fit quality at ~35-40x its speed; the remaining gap is a known, understood
limitation (see the core crate PR), not something silently swept under the rug.

`bolometric='linexp'` and `spectral='blanketed'` aren't implemented yet (same gap as the core
crate) -- use `light_curve_py.RainbowFit` for those.

Depends on an unreleased `light-curve-feature` version, temporarily pinned to a fork branch in
`Cargo.toml` pending upstream review; will switch to a plain crates.io dependency once that
merges and releases.