### PR TITLE
Say which date goes in the changelog

### DIFF
--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -216,7 +216,8 @@ Pre-built free-threaded wheels are not yet published to PyPI.
 ## Publishing a release
 
 1. Create a `release-vX.Y.Z` branch from `main`.
-2. Update `CHANGELOG.md` with the new version and date.
+2. Update `CHANGELOG.md` with the new version and date — the **UTC** date you expect the release
+   to land on PyPI.
 3. Update the version in `Cargo.toml` (the Python package version is read from there), then run
    `cargo update` to update `Cargo.lock`.
 4. Commit, push the branch, and open a PR into `main`.


### PR DESCRIPTION
Step 2 of "Publishing a release" just said "the new version and date", which left the date
ambiguous. It is the UTC date the release lands on PyPI — prepare a release late enough in the
day in a western timezone and the local date is already a day behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)